### PR TITLE
Fixed NotSupportedException.

### DIFF
--- a/CodeMaid/Model/Comments/CommentMatch.cs
+++ b/CodeMaid/Model/Comments/CommentMatch.cs
@@ -37,7 +37,7 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
             // In the case of a list prefix but no content (e.g. hyphen line) convert to regular content.
             if (IsEmpty && IsList)
             {
-                Words = new[] { ListPrefix };
+                Words = new List<string>(new[] { ListPrefix });
                 ListPrefix = null;
                 IsEmpty = false;
                 IsList = false;


### PR DESCRIPTION
Whenever CodeCommentMatch constructor ended up with Words == null, it would assign it a default value in a form of an array, which later on would NotSupportedException to be raised, due to TryAppend attempting to Add method on IList object, which is not supported with arrays.
