### PR TITLE
Fixed NullReferenceException in CommentFormatter.ParseXml

### DIFF
--- a/CodeMaid/Model/Comments/CommentFormatter.cs
+++ b/CodeMaid/Model/Comments/CommentFormatter.cs
@@ -112,6 +112,10 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
 
         private void Append(string value)
         {
+            if (String.IsNullOrEmpty(value))
+            {
+                return;
+            }
             _builder.Append(_options.XmlKeepTagsTogether ? CodeCommentHelper.FakeToSpace(value) : value);
             _currentPosition += WordLength(value);
             _isFirstWord = false;


### PR DESCRIPTION
Sometimes during ParseXml it would try calling CommentFormatter.Append and give it null as an argument, which would cause the exception to be thrown. I don't know what causes it to pass null.

Here is the comment that produced the issue:

``` cs
/// <summary>
/// When implemented in derived class, processes an event that is not processed
/// anywhere else.
/// </summary>
/// <remarks>
/// Documentation for <see cref="EntityEvent"/> contains details about each event
/// along with descriptions of each parameter.
/// </remarks>
/// <param name="event">           Event to process.</param>
/// <param name="parameter0">      Optional first integer parameter.</param>
/// <param name="parameter1">      Optional second integer parameter.</param>
/// <param name="parameter2">      Optional third integer parameter.</param>
/// <param name="parameter3">      Optional fourth integer parameter.</param>
/// <param name="singleParameter0">
/// Optional first floating point parameter.
/// </param>
/// <param name="singleParameter1">
/// Optional second floating point parameter.
/// </param>
/// <seealso cref="EntityEvent"/>
```

seealso tag seems to be the main offender here: removing it allowed CodeMaid to format everything properly.
