### PR TITLE
Updated comment formatting logic to address some issues.

### DIFF
--- a/CodeMaid.UnitTests/CodeMaid.UnitTests.csproj
+++ b/CodeMaid.UnitTests/CodeMaid.UnitTests.csproj
@@ -88,8 +88,9 @@
     <Compile Include="CachedSettingTests.cs" />
     <Compile Include="Formatting\CommentFormatHelper.cs" />
     <Compile Include="Formatting\HeaderFormattingTests.cs" />
-    <Compile Include="Formatting\XmlFormattingTests.cs" />
     <Compile Include="Formatting\SimpleFormattingTests.cs" />
+    <Compile Include="Formatting\XmlFormattingTests.cs" />
+    <Compile Include="Formatting\ListFormattingTests.cs" />
     <Compile Include="Helpers\CodeMaidPackageHelper.cs" />
     <Compile Include="Helpers\UIShellServiceMock.cs" />
     <Compile Include="Helpers\WindowFrameMock.cs" />

--- a/CodeMaid.UnitTests/Formatting/ListFormattingTests.cs
+++ b/CodeMaid.UnitTests/Formatting/ListFormattingTests.cs
@@ -16,74 +16,74 @@ using SteveCadwallader.CodeMaid.Properties;
 
 namespace SteveCadwallader.CodeMaid.UnitTests.Formatting
 {
-	/// <summary>
-	/// Class with simple unit tests for formatting. This calls the formatter directly, rather than
-	/// invoking it through the UI as with the integration tests.
-	/// </summary>
-	[TestClass]
-	public class ListFormattingTests
-	{
-		[TestMethod]
-		[TestCategory("Formatting UnitTests")]
-		public void ListFormattingTests_DashedList()
-		{
-			var input =
-				@"Some text before." + Environment.NewLine +
-				@"- The first item with enough words to require wrapping." + Environment.NewLine +
-				@"- The second item with enough words to require wrapping." + Environment.NewLine +
-				@"Some trialing text.";
+    /// <summary>
+    /// Class with simple unit tests for formatting. This calls the formatter directly, rather than
+    /// invoking it through the UI as with the integration tests.
+    /// </summary>
+    [TestClass]
+    public class ListFormattingTests
+    {
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
+        public void ListFormattingTests_DashedList()
+        {
+            var input =
+                @"Some text before." + Environment.NewLine +
+                @"- The first item with enough words to require wrapping." + Environment.NewLine +
+                @"- The second item with enough words to require wrapping." + Environment.NewLine +
+                @"Some trialing text.";
 
-			var expected =
-				@"Some text before." + Environment.NewLine +
-				@"- The first item with enough" + Environment.NewLine +
-				@"  words to require wrapping." + Environment.NewLine +
-				@"- The second item with enough" + Environment.NewLine +
-				@"  words to require wrapping." + Environment.NewLine +
-				@"Some trialing text.";
+            var expected =
+                @"Some text before." + Environment.NewLine +
+                @"- The first item with enough" + Environment.NewLine +
+                @"  words to require wrapping." + Environment.NewLine +
+                @"- The second item with enough" + Environment.NewLine +
+                @"  words to require wrapping." + Environment.NewLine +
+                @"Some trialing text.";
 
-			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default) { WrapAtColumn = 30 });
-		}
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default) { WrapAtColumn = 30 });
+        }
 
-		[TestMethod]
-		[TestCategory("Formatting UnitTests")]
-		public void ListFormattingTests_NumberedList()
-		{
-			var input =
-				@"Some text before." + Environment.NewLine +
-				@"1) The first item with enough words to require wrapping." + Environment.NewLine +
-				@"2) The second item with enough words to require wrapping." + Environment.NewLine +
-				@"Some trialing text.";
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
+        public void ListFormattingTests_NumberedList()
+        {
+            var input =
+                @"Some text before." + Environment.NewLine +
+                @"1) The first item with enough words to require wrapping." + Environment.NewLine +
+                @"2) The second item with enough words to require wrapping." + Environment.NewLine +
+                @"Some trialing text.";
 
-			var expected =
-				@"Some text before." + Environment.NewLine +
-				@"1) The first item with enough" + Environment.NewLine +
-				@"   words to require wrapping." + Environment.NewLine +
-				@"2) The second item with enough" + Environment.NewLine +
-				@"   words to require wrapping." + Environment.NewLine +
-				@"Some trialing text.";
+            var expected =
+                @"Some text before." + Environment.NewLine +
+                @"1) The first item with enough" + Environment.NewLine +
+                @"   words to require wrapping." + Environment.NewLine +
+                @"2) The second item with enough" + Environment.NewLine +
+                @"   words to require wrapping." + Environment.NewLine +
+                @"Some trialing text.";
 
-			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default) { WrapAtColumn = 30 });
-		}
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default) { WrapAtColumn = 30 });
+        }
 
-		[TestMethod]
-		[TestCategory("Formatting UnitTests")]
-		public void ListFormattingTests_WordList()
-		{
-			var input =
-				@"Some text before." + Environment.NewLine +
-				@"item) The first item with enough words to require wrapping." + Environment.NewLine +
-				@"meti) The second item with enough words to require wrapping." + Environment.NewLine +
-				@"Some trialing text.";
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
+        public void ListFormattingTests_WordList()
+        {
+            var input =
+                @"Some text before." + Environment.NewLine +
+                @"item) The first item with enough words to require wrapping." + Environment.NewLine +
+                @"meti) The second item with enough words to require wrapping." + Environment.NewLine +
+                @"Some trialing text.";
 
-			var expected =
-				@"Some text before." + Environment.NewLine +
-				@"item) The first item with enough" + Environment.NewLine +
-				@"      words to require wrapping." + Environment.NewLine +
-				@"meti) The second item with enough" + Environment.NewLine +
-				@"      words to require wrapping." + Environment.NewLine +
-				@"Some trialing text.";
+            var expected =
+                @"Some text before." + Environment.NewLine +
+                @"item) The first item with enough" + Environment.NewLine +
+                @"      words to require wrapping." + Environment.NewLine +
+                @"meti) The second item with enough" + Environment.NewLine +
+                @"      words to require wrapping." + Environment.NewLine +
+                @"Some trialing text.";
 
-			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default) { WrapAtColumn = 35 });
-		}
-	}
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default) { WrapAtColumn = 35 });
+        }
+    }
 }

--- a/CodeMaid.UnitTests/Formatting/ListFormattingTests.cs
+++ b/CodeMaid.UnitTests/Formatting/ListFormattingTests.cs
@@ -1,0 +1,89 @@
+﻿#region CodeMaid is Copyright 2007-2015 Steve Cadwallader.
+
+// CodeMaid is free software: you can redistribute it and/or modify it under the terms of the GNU
+// Lesser General Public License version 3 as published by the Free Software Foundation.
+//
+// CodeMaid is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details <http://www.gnu.org/licenses/>.
+
+#endregion CodeMaid is Copyright 2007-2015 Steve Cadwallader.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SteveCadwallader.CodeMaid.Model.Comments;
+using SteveCadwallader.CodeMaid.Properties;
+
+namespace SteveCadwallader.CodeMaid.UnitTests.Formatting
+{
+	/// <summary>
+	/// Class with simple unit tests for formatting. This calls the formatter directly, rather than
+	/// invoking it through the UI as with the integration tests.
+	/// </summary>
+	[TestClass]
+	public class ListFormattingTests
+	{
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void ListFormattingTests_DashedList()
+		{
+			var input =
+				@"Some text before." + Environment.NewLine +
+				@"- The first item with enough words to require wrapping." + Environment.NewLine +
+				@"- The second item with enough words to require wrapping." + Environment.NewLine +
+				@"Some trialing text.";
+
+			var expected =
+				@"Some text before." + Environment.NewLine +
+				@"- The first item with enough" + Environment.NewLine +
+				@"  words to require wrapping." + Environment.NewLine +
+				@"- The second item with enough" + Environment.NewLine +
+				@"  words to require wrapping." + Environment.NewLine +
+				@"Some trialing text.";
+
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default) { WrapAtColumn = 30 });
+		}
+
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void ListFormattingTests_NumberedList()
+		{
+			var input =
+				@"Some text before." + Environment.NewLine +
+				@"1) The first item with enough words to require wrapping." + Environment.NewLine +
+				@"2) The second item with enough words to require wrapping." + Environment.NewLine +
+				@"Some trialing text.";
+
+			var expected =
+				@"Some text before." + Environment.NewLine +
+				@"1) The first item with enough" + Environment.NewLine +
+				@"   words to require wrapping." + Environment.NewLine +
+				@"2) The second item with enough" + Environment.NewLine +
+				@"   words to require wrapping." + Environment.NewLine +
+				@"Some trialing text.";
+
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default) { WrapAtColumn = 30 });
+		}
+
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void ListFormattingTests_WordList()
+		{
+			var input =
+				@"Some text before." + Environment.NewLine +
+				@"item) The first item with enough words to require wrapping." + Environment.NewLine +
+				@"meti) The second item with enough words to require wrapping." + Environment.NewLine +
+				@"Some trialing text.";
+
+			var expected =
+				@"Some text before." + Environment.NewLine +
+				@"item) The first item with enough" + Environment.NewLine +
+				@"      words to require wrapping." + Environment.NewLine +
+				@"meti) The second item with enough" + Environment.NewLine +
+				@"      words to require wrapping." + Environment.NewLine +
+				@"Some trialing text.";
+
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default) { WrapAtColumn = 35 });
+		}
+	}
+}

--- a/CodeMaid.UnitTests/Formatting/SimpleFormattingTests.cs
+++ b/CodeMaid.UnitTests/Formatting/SimpleFormattingTests.cs
@@ -133,7 +133,25 @@ namespace SteveCadwallader.CodeMaid.UnitTests.Formatting
             });
         }
 
-        [TestMethod]
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void SimpleFormattingTests_HyperlinkOnNewLine()
+		{
+			var input = "http://foo";
+			CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default));
+		}
+
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void SimpleFormattingTests_HyperlinkBetweenWords()
+		{
+			var input = "Look at this http://foo pretty link.";
+			CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default));
+		}
+
+
+
+		[TestMethod]
         [TestCategory("Formatting UnitTests")]
         public void SimpleFormattingTests_WrapsLinesAsExpected()
         {

--- a/CodeMaid.UnitTests/Formatting/XmlFormattingTests.cs
+++ b/CodeMaid.UnitTests/Formatting/XmlFormattingTests.cs
@@ -9,252 +9,268 @@
 
 #endregion CodeMaid is Copyright 2007-2015 Steve Cadwallader.
 
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SteveCadwallader.CodeMaid.Model.Comments;
 using SteveCadwallader.CodeMaid.Properties;
-using System;
 
 namespace SteveCadwallader.CodeMaid.UnitTests.Formatting
 {
-    /// <summary>
-    /// Class with simple unit tests for formatting XML based comments. This calls the formatter
-    /// directly, rather than invoking it through the UI as with the integration tests.
-    /// </summary>
-    [TestClass]
-    public class XmlFormattingTests
-    {
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_AddSpaceToInsideTags()
-        {
-            var input = "<summary><see/></summary>";
-            var expected = "<summary><see /></summary>";
+	/// <summary>
+	/// Class with simple unit tests for formatting XML based comments. This calls the formatter
+	/// directly, rather than invoking it through the UI as with the integration tests.
+	/// </summary>
+	[TestClass]
+	public class XmlFormattingTests
+	{
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_AddSpaceToInsideTags()
+		{
+			var input = "<summary><see/></summary>";
+			var expected = "<summary><see /></summary>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = false,
-                XmlSpaceSingleTags = true
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = false,
+				XmlSpaceSingleTags = true
+			});
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_AddSpaceToTagContent()
-        {
-            var input = "<summary><c>test</c></summary>";
-            var expected = "<summary> <c> test </c> </summary>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_AddSpaceToTagContent()
+		{
+			var input = "<summary><c>test</c></summary>";
+			var expected = "<summary> <c> test </c> </summary>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = false,
-                XmlSpaceTagContent = true
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = false,
+				XmlSpaceTagContent = true
+			});
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_AllRootLevelTagsOnNewLine()
-        {
-            var input = "<summary>abc</summary><returns>abc</returns>";
-            var expected = "<summary>abc</summary>" + Environment.NewLine + "<returns>abc</returns>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_AllRootLevelTagsOnNewLine()
+		{
+			var input = "<summary>abc</summary><returns>abc</returns>";
+			var expected = "<summary>abc</summary>" + Environment.NewLine + "<returns>abc</returns>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = false
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = false
+			});
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_BreakAllTags()
-        {
-            var input = "<summary></summary><returns></returns>";
-            var expected = "<summary>" + Environment.NewLine + "</summary>" + Environment.NewLine + "<returns>" + Environment.NewLine + "</returns>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_BreakAllTags()
+		{
+			var input = "<summary></summary><returns></returns>";
+			var expected = "<summary>" + Environment.NewLine + "</summary>" + Environment.NewLine + "<returns>" + Environment.NewLine + "</returns>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = true
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = true
+			});
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_BreakSummaryTags()
-        {
-            var input = "<summary></summary><returns></returns>";
-            var expected = "<summary>" + Environment.NewLine + "</summary>" + Environment.NewLine + "<returns></returns>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_BreakSummaryTags()
+		{
+			var input = "<summary></summary><returns></returns>";
+			var expected = "<summary>" + Environment.NewLine + "</summary>" + Environment.NewLine + "<returns></returns>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = true,
-                XmlSplitAllTags = false
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = true,
+				XmlSplitAllTags = false
+			});
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_DoNotAutoCollapseTags()
-        {
-            var input = "<summary></summary>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_DoNotAutoCollapseTags()
+		{
+			var input = "<summary></summary>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = false
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = false
+			});
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_DoNotAutoExpandTags()
-        {
-            var input = "<summary/>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_DoNotAutoExpandTags()
+		{
+			var input = "<summary/>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = false
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = false
+			});
+		}
 
-        /// <summary>
-        /// Test to make sure there is no spacing is added between an inline XML tag directly
-        /// followed by interpunction.
-        /// </summary>
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_InterpunctionNoSpacing()
-        {
-            var input = "<test>Line with <interpunction/>.</test>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_HyperlinkOnNewLine()
+		{
+			var input = "<summary>" + Environment.NewLine + "http://foo" + Environment.NewLine + "</summary>";
+			CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default));
+		}
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = false,
-                SkipWrapOnLastWord = false
-            });
-        }
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_HyperlinkBetweenWords()
+		{
+			var input = "<summary>" + Environment.NewLine + "Look at this http://foo pretty link." + Environment.NewLine + "</summary>";
+			CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default));
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_KeepCodeFormatting()
-        {
-            var input =
-                "<test><code>" + Environment.NewLine +
-                "some" + Environment.NewLine +
-                "  code" + Environment.NewLine +
-                "stuff" + Environment.NewLine +
-                "</code></test>";
+		/// <summary>
+		/// Test to make sure there is no spacing is added between an inline XML tag directly
+		/// followed by interpunction.
+		/// </summary>
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_InterpunctionNoSpacing()
+		{
+			var input = "<test>Line with <interpunction/>.</test>";
 
-            var expected =
-                "<test>" + Environment.NewLine +
-                "<code>" + Environment.NewLine +
-                "some" + Environment.NewLine +
-                "  code" + Environment.NewLine +
-                "stuff" + Environment.NewLine +
-                "</code>" + Environment.NewLine +
-                "</test>";
+			CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = false,
+				SkipWrapOnLastWord = false
+			});
+		}
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = false
-            });
-        }
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_KeepCodeFormatting()
+		{
+			var input =
+				"<test><code>" + Environment.NewLine +
+				"some" + Environment.NewLine +
+				"  code" + Environment.NewLine +
+				"stuff" + Environment.NewLine +
+				"</code></test>";
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_RemoveSpaceFromInsideTags()
-        {
-            var input = "<summary><see /></summary>";
-            var expected = "<summary><see/></summary>";
+			var expected =
+				"<test>" + Environment.NewLine +
+				"<code>" + Environment.NewLine +
+				"some" + Environment.NewLine +
+				"  code" + Environment.NewLine +
+				"stuff" + Environment.NewLine +
+				"</code>" + Environment.NewLine +
+				"</test>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = false,
-                XmlSpaceSingleTags = false
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = false
+			});
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_RemoveSpaceFromTagContent()
-        {
-            var input = "<summary> <c> test </c> </summary>";
-            var expected = "<summary><c>test</c></summary>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_RemoveSpaceFromInsideTags()
+		{
+			var input = "<summary><see /></summary>";
+			var expected = "<summary><see/></summary>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = false,
-                XmlSpaceTagContent = false
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = false,
+				XmlSpaceSingleTags = false
+			});
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_SplitsTagsWhenLineDoesNotFit()
-        {
-            var input = "<test>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus nisi neque, placerat sed neque vitae</test>";
-            var expected = "<test>" + Environment.NewLine +
-                "Lorem ipsum dolor sit amet, consectetur adipiscing" + Environment.NewLine +
-                "elit. Vivamus nisi neque, placerat sed neque vitae" + Environment.NewLine +
-                "</test>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_RemoveSpaceFromTagContent()
+		{
+			var input = "<summary> <c> test </c> </summary>";
+			var expected = "<summary><c>test</c></summary>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 50,
-                XmlSplitSummaryTag = false,
-                XmlSplitAllTags = false,
-                SkipWrapOnLastWord = false
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = false,
+				XmlSpaceTagContent = false
+			});
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_TagNameKeepCase()
-        {
-            var input = "<Summary></Summary>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_SplitsTagsWhenLineDoesNotFit()
+		{
+			var input = "<test>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus nisi neque, placerat sed neque vitae</test>";
+			var expected = "<test>" + Environment.NewLine +
+				"Lorem ipsum dolor sit amet, consectetur adipiscing" + Environment.NewLine +
+				"elit. Vivamus nisi neque, placerat sed neque vitae" + Environment.NewLine +
+				"</test>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlTagsToLowerCase = false,
-                XmlSplitAllTags = false,
-                XmlSplitSummaryTag = false
-            });
-        }
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 50,
+				XmlSplitSummaryTag = false,
+				XmlSplitAllTags = false,
+				SkipWrapOnLastWord = false
+			});
+		}
 
-        [TestMethod]
-        [TestCategory("Formatting UnitTests")]
-        public void XmlFormattingTests_TagNameToLowerCase()
-        {
-            var input = "<Summary></Summary>";
-            var expected = "<summary></summary>";
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_TagNameKeepCase()
+		{
+			var input = "<Summary></Summary>";
 
-            CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
-            {
-                WrapAtColumn = 100,
-                XmlTagsToLowerCase = true,
-                XmlSplitAllTags = false,
-                XmlSplitSummaryTag = false
-            });
-        }
-    }
+			CommentFormatHelper.AssertEqualAfterFormat(input, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlTagsToLowerCase = false,
+				XmlSplitAllTags = false,
+				XmlSplitSummaryTag = false
+			});
+		}
+
+		[TestMethod]
+		[TestCategory("Formatting UnitTests")]
+		public void XmlFormattingTests_TagNameToLowerCase()
+		{
+			var input = "<Summary></Summary>";
+			var expected = "<summary></summary>";
+
+			CommentFormatHelper.AssertEqualAfterFormat(input, expected, new CodeCommentOptions(Settings.Default)
+			{
+				WrapAtColumn = 100,
+				XmlTagsToLowerCase = true,
+				XmlSplitAllTags = false,
+				XmlSplitSummaryTag = false
+			});
+		}
+	}
 }

--- a/CodeMaid/Helpers/CodeCommentHelper.cs
+++ b/CodeMaid/Helpers/CodeCommentHelper.cs
@@ -9,10 +9,10 @@
 
 #endregion CodeMaid is Copyright 2007-2015 Steve Cadwallader.
 
-using EnvDTE;
-using SteveCadwallader.CodeMaid.Model.Comments;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using EnvDTE;
+using SteveCadwallader.CodeMaid.Model.Comments;
 
 namespace SteveCadwallader.CodeMaid.Helpers
 {

--- a/CodeMaid/Helpers/CodeCommentHelper.cs
+++ b/CodeMaid/Helpers/CodeCommentHelper.cs
@@ -148,7 +148,7 @@ namespace SteveCadwallader.CodeMaid.Helpers
                 prefix = string.Format(@"(?<prefix>[\t ]*{0})(?<initialspacer>( |\t|\r|\n|$))?", prefix);
             }
 
-            var pattern = string.Format(@"^{0}(?<line>(?<indent>[\t ]*)(?<listprefix>[-=\*\+]+|\w+[\):]|\d+\.)?((?<words>[^\t\r\n ]+)*[\t ]*)*)[\r]*[\n]?$", prefix);
+            var pattern = string.Format(@"^{0}(?<line>(?<indent>[\t ]*)(?<listprefix>[-=\*\+]+|\w+[\):]\s|\d+\.\s)?((?<words>[^\t\r\n ]+)*[\t ]*)*)[\r]*[\n]?$", prefix);
             return new Regex(pattern, RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.Multiline);
         }
 

--- a/CodeMaid/Helpers/CodeCommentHelper.cs
+++ b/CodeMaid/Helpers/CodeCommentHelper.cs
@@ -148,7 +148,7 @@ namespace SteveCadwallader.CodeMaid.Helpers
                 prefix = string.Format(@"(?<prefix>[\t ]*{0})(?<initialspacer>( |\t|\r|\n|$))?", prefix);
             }
 
-            var pattern = string.Format(@"^{0}(?<line>(?<indent>[\t ]*)(?<listprefix>[-=\*\+]+|\w+[\):]\s|\d+\.\s)?((?<words>[^\t\r\n ]+)*[\t ]*)*)[\r]*[\n]?$", prefix);
+            var pattern = string.Format(@"^{0}(?<line>(?<indent>[\t ]*)(?<listprefix>[-=\*\+]+[ \t]*|\w+[\):][ \t]+|\d+\.[ \t]+)?((?<words>[^\t\r\n ]+)*[\t ]*)*)[\r]*[\n]?$", prefix);
             return new Regex(pattern, RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.Multiline);
         }
 

--- a/CodeMaid/Model/Comments/CodeComment.cs
+++ b/CodeMaid/Model/Comments/CodeComment.cs
@@ -9,216 +9,229 @@
 
 #endregion CodeMaid is Copyright 2007-2015 Steve Cadwallader.
 
-using EnvDTE;
-using SteveCadwallader.CodeMaid.Helpers;
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using EnvDTE;
+using SteveCadwallader.CodeMaid.Helpers;
 
 namespace SteveCadwallader.CodeMaid.Model.Comments
 {
-    /// <summary>
-    /// A <c>CodeComment</c> contains one or more <see cref="CodeCommentPhrase">phrases</see> which
-    /// represent all the content of a comment.
-    /// </summary>
-    internal class CodeComment
-    {
-        #region Fields
+	/// <summary>
+	/// A <c>CodeComment</c> contains one or more <see cref="CodeCommentPhrase">phrases</see> which
+	/// represent all the content of a comment.
+	/// </summary>
+	internal class CodeComment
+	{
+		#region Fields
 
-        private readonly TextDocument _document;
-        private Regex _commentLineRegex;
+		private readonly TextDocument _document;
+		private Regex _commentLineRegex;
 
-        private EditPoint _endPoint;
-        private EditPoint _startPoint;
+		private EditPoint _endPoint;
+		private EditPoint _startPoint;
 
-        #endregion Fields
+		#endregion Fields
 
-        #region Constructors
+		#region Constructors
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CodeComment" /> class.
-        /// </summary>
-        public CodeComment(TextPoint point)
-        {
-            if (point == null)
-            {
-                throw new ArgumentNullException("point");
-            }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CodeComment" /> class.
+		/// </summary>
+		public CodeComment(TextPoint point)
+		{
+			if (point == null)
+			{
+				throw new ArgumentNullException("point");
+			}
 
-            _document = point.Parent;
+			_document = point.Parent;
 
-            _commentLineRegex = CodeCommentHelper.GetCommentRegex(_document.Language, true);
+			_commentLineRegex = CodeCommentHelper.GetCommentRegex(_document.Language, true);
 
-            Expand(point);
-        }
+			Expand(point);
+		}
 
-        #endregion Constructors
+		#endregion Constructors
 
-        #region Properties
+		#region Properties
 
-        public TextPoint EndPoint { get { return _endPoint; } }
+		public TextPoint EndPoint { get { return _endPoint; } }
 
-        public bool IsValid { get; private set; }
+		public bool IsValid { get; private set; }
 
-        public TextPoint StartPoint { get { return _startPoint; } }
+		public TextPoint StartPoint { get { return _startPoint; } }
 
-        #endregion Properties
+		#endregion Properties
 
-        #region Methods
+		#region Methods
 
-        /// <summary>
-        /// Helper function to generate the preview in the options menu.
-        /// </summary>
-        public static string FormatXml(string text, CodeCommentOptions options)
-        {
-            var xml = XElement.Parse(string.Format("<doc>{0}</doc>", text));
-            var line = new CommentLineXml(xml, options);
-            var regex = CodeCommentHelper.GetCommentRegex("CSharp", false);
-            var formatter = new CommentFormatter(line, "///", options, regex);
+		/// <summary>
+		/// Helper function to generate the preview in the options menu.
+		/// </summary>
+		public static string FormatXml(string text, CodeCommentOptions options)
+		{
+			var xml = XElement.Parse(string.Format("<doc>{0}</doc>", text));
+			var line = new CommentLineXml(xml, options);
+			var regex = CodeCommentHelper.GetCommentRegex("CSharp", false);
+			var formatter = new CommentFormatter(line, "///", options, regex);
 
-            return formatter.ToString();
-        }
+			return formatter.ToString();
+		}
 
-        /// <summary>
-        /// Formats the comment.
-        /// </summary>
-        /// <param name="options">The options to be used for formatting.</param>
-        public TextPoint Format(CodeCommentOptions options)
-        {
-            if (!IsValid)
-            {
-                throw new InvalidOperationException("Cannot format comment, the comment is not valid.");
-            }
+		/// <summary>
+		/// Formats the comment.
+		/// </summary>
+		/// <param name="options">The options to be used for formatting.</param>
+		public TextPoint Format(CodeCommentOptions options)
+		{
+			if (!IsValid)
+			{
+				throw new InvalidOperationException("Cannot format comment, the comment is not valid.");
+			}
 
-            var originalText = _startPoint.GetText(_endPoint);
-            var matches = _commentLineRegex.Matches(originalText).OfType<Match>().ToArray();
-            var commentPrefix = matches.First(m => m.Success).Groups["prefix"].Value;
+			var originalText = _startPoint.GetText(_endPoint);
+			var matches = _commentLineRegex.Matches(originalText).OfType<Match>().ToArray();
+			var commentPrefix = matches.First(m => m.Success).Groups["prefix"].Value;
 
-            // Concatenate the comment lines without comment prefixes and see if the resulting bit
-            // can be parsed as XML.
-            ICommentLine line = null;
-            var lineTexts = matches.Select(m => m.Groups["line"].Value).ToArray();
-            var commentText = string.Join(Environment.NewLine, lineTexts);
-            if (commentText.Contains('<'))
-            {
-                try
-                {
-                    var xml = XElement.Parse(string.Format("<doc>{0}</doc>", commentText));
-                    line = new CommentLineXml(xml, options);
-                }
-                catch (System.Xml.XmlException)
-                {
-                    // If XML cannot be parsed, comment will be handled as a normal text comment.
-                }
-            }
+			// Concatenate the comment lines without comment prefixes and see if the resulting bit
+			// can be parsed as XML.
+			ICommentLine line = null;
+			var lineTexts = matches.Select(m => m.Groups["line"].Value).ToArray();
+			var commentText = string.Join(Environment.NewLine, lineTexts);
+			if (commentText.Contains('<'))
+			{
+				try
+				{
+					var xml = XElement.Parse(string.Format("<doc>{0}</doc>", commentText));
+					line = new CommentLineXml(xml, options);
+				}
+				catch (System.Xml.XmlException)
+				{
+					// If XML cannot be parsed, comment will be handled as a normal text comment.
+				}
+			}
 
-            if (line == null)
-            {
-                line = new CommentLine(commentText);
-            }
+			if (line == null)
+			{
+				line = new CommentLine(commentText);
+			}
 
-            var formatter = new CommentFormatter(
-                line,
-                commentPrefix,
-                options,
-                CodeCommentHelper.GetCommentRegex(_document.Language, false));
+			var formatter = new CommentFormatter(
+				line,
+				commentPrefix,
+				options,
+				CodeCommentHelper.GetCommentRegex(_document.Language, false));
 
-            if (!formatter.Equals(originalText))
-            {
-                var cursor = StartPoint.CreateEditPoint();
-                cursor.Delete(EndPoint);
-                cursor.Insert(formatter.ToString());
-                _endPoint = cursor.CreateEditPoint();
-            }
+			if (!formatter.Equals(originalText))
+			{
+				var cursor = StartPoint.CreateEditPoint();
+				cursor.Delete(EndPoint);
+				cursor.Insert(formatter.ToString());
+				_endPoint = cursor.CreateEditPoint();
+			}
 
-            return EndPoint;
-        }
+			return EndPoint;
+		}
 
-        /// <summary>
-        /// Expands a text point to the full comment.
-        /// </summary>
-        /// <param name="point">The original text point to expand from.</param>
-        private void Expand(TextPoint point)
-        {
-            var i = point.CreateEditPoint();
+		/// <summary>
+		/// Expands a text point to the full comment.
+		/// </summary>
+		/// <param name="point">The original text point to expand from.</param>
+		private void Expand(TextPoint point)
+		{
+			var i = point.CreateEditPoint();
 
-            // Look up to find the start of the comment.
-            _startPoint = Expand(point, p => p.LineUp());
+			// Look up to find the start of the comment.
+			_startPoint = Expand(point, p => p.LineUp());
 
-            // If a valid start is found, look down to find the end of the comment.
-            if (_startPoint != null)
-            {
-                _endPoint = Expand(point, p => p.LineDown());
-            }
+			// If a valid start is found, look down to find the end of the comment.
+			if (_startPoint != null)
+			{
+				_endPoint = Expand(point, p => p.LineDown());
+			}
 
-            if (StartPoint != null && EndPoint != null)
-            {
-                _startPoint.StartOfLine();
-                _endPoint.EndOfLine();
-                IsValid = true;
-            }
-            else
-            {
-                IsValid = false;
-            }
-        }
+			// If both start and endpoint are valid, the comment is valid.
+			if (_startPoint != null && _endPoint != null)
+			{
+				_startPoint.StartOfLine();
+				_endPoint.EndOfLine();
+				IsValid = true;
+			}
+			else
+			{
+				IsValid = false;
+			}
+		}
 
-        private EditPoint Expand(TextPoint point, Action<EditPoint> foundAction)
-        {
-            EditPoint current = point.CreateEditPoint();
-            EditPoint result = null;
-            string prefix = null;
+		/// <summary>
+		/// Expand a textpoint to the full comment, in the direction specified by the <paramref name="foundAction"/>.
+		/// </summary>
+		/// <param name="point">The initial starting point for the expansion.</param>
+		/// <param name="foundAction">An action which advances the search either up or down.</param>
+		/// <returns>
+		/// The endpoint of the comment, or <c>null</c> if the expansion did not find a valid comment.
+		/// </returns>
+		private EditPoint Expand(TextPoint point, Action<EditPoint> foundAction)
+		{
+			EditPoint current = point.CreateEditPoint();
+			EditPoint result = null;
+			string prefix = null;
 
-            do
-            {
-                var line = current.Line;
-                var text = current.GetLine();
+			do
+			{
+				var line = current.Line;
+				var text = current.GetLine();
 
-                var match = _commentLineRegex.Match(text);
-                if (match.Success)
-                {
-                    // The initial spacer is required, otherwise we assume this is commented out
-                    // code and do not format.
-                    if (match.Groups["initialspacer"].Success)
-                    {
-                        // Get the comment prefix for the current line.
-                        var currentPrefix = match.Groups["prefix"].Value.TrimStart();
-                        if (prefix == null) { prefix = currentPrefix; }
+				var match = _commentLineRegex.Match(text);
+				if (match.Success)
+				{
+					// Cancel the expansion if the prefix does not match. This takes priority over
+					// the initial spacer check to allow formatting comments adjacent to Stylecop
+					// SA1626 style commented code.
+					var currentPrefix = match.Groups["prefix"].Value.TrimStart();
+					if (prefix != null && !string.Equals(prefix, currentPrefix))
+					{
+						break;
+					}
+					else
+					{
+						prefix = currentPrefix;
+					}
 
-                        // Cancel the expanding if the prefix does not match.
-                        if (prefix != currentPrefix)
-                        {
-                            break;
-                        }
+					// The initial spacer is required, otherwise we assume this is commented out
+					// code and do not format.
+					if (match.Groups["initialspacer"].Success)
+					{
+						result = current.CreateEditPoint();
+						foundAction(current);
 
-                        result = current.CreateEditPoint();
-                        foundAction(current);
+						// If result and iterator line are the same, the found action (move line up or
+						// down) did nothing. This means we're at the start or end of the file, and
+						// there is no point to keep searching, it would create an infinite loop.
+						if (result.Line == current.Line)
+						{
+							break;
+						}
+					}
+					else
+					{
+						// Did not succesfully match the intial spacer, we have to assume this is
+						// code and cancel all formatting.
+						result = null;
+						current = null;
+					}
+				}
+				else
+				{
+					current = null;
+				}
+			} while (current != null);
 
-                        // If result and iterator line are the same, the found action (move line up or
-                        // down) did nothing. This means we're at the start or end of the file, and
-                        // there is no point to keep searching, it would create an infinite loop.
-                        if (result.Line == current.Line)
-                        {
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        // This is code! Set to null to abandon loop.
-                        result = null;
-                        current = null;
-                    }
-                }
-                else
-                {
-                    current = null;
-                }
-            } while (current != null);
+			return result;
+		}
 
-            return result;
-        }
-
-        #endregion Methods
-    }
+		#endregion Methods
+	}
 }

--- a/CodeMaid/Model/Comments/CommentFormatter.cs
+++ b/CodeMaid/Model/Comments/CommentFormatter.cs
@@ -234,9 +234,12 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
                         }
 
                         Append(match.ListPrefix);
-                    }
+						// List items include their spacing and do not require additional space,
+						// thus we are logically still on the first word.
+						_isFirstWord = true;
+					}
 
-                    if (match.Words != null)
+					if (match.Words != null)
                     {
                         var wordCount = match.Words.Count - 1;
 
@@ -266,9 +269,12 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
                             {
                                 NewLine(indentLevel);
 
+								// If linewrap is on a list item, add spacing to align the text.
                                 if (match.IsList)
                                 {
                                     Append(string.Empty.PadLeft(WordLength(match.ListPrefix), CodeCommentHelper.Spacer));
+									// This is just padding and not a word.
+									_isFirstWord = true;
                                 }
                             }
 

--- a/CodeMaid/Model/Comments/CommentFormatter.cs
+++ b/CodeMaid/Model/Comments/CommentFormatter.cs
@@ -9,11 +9,11 @@
 
 #endregion CodeMaid is Copyright 2007-2015 Steve Cadwallader.
 
-using SteveCadwallader.CodeMaid.Helpers;
 using System;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using SteveCadwallader.CodeMaid.Helpers;
 
 namespace SteveCadwallader.CodeMaid.Model.Comments
 {
@@ -234,12 +234,12 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
                         }
 
                         Append(match.ListPrefix);
-						// List items include their spacing and do not require additional space,
-						// thus we are logically still on the first word.
-						_isFirstWord = true;
-					}
+                        // List items include their spacing and do not require additional space,
+                        // thus we are logically still on the first word.
+                        _isFirstWord = true;
+                    }
 
-					if (match.Words != null)
+                    if (match.Words != null)
                     {
                         var wordCount = match.Words.Count - 1;
 
@@ -269,12 +269,12 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
                             {
                                 NewLine(indentLevel);
 
-								// If linewrap is on a list item, add spacing to align the text.
+                                // If linewrap is on a list item, add spacing to align the text.
                                 if (match.IsList)
                                 {
                                     Append(string.Empty.PadLeft(WordLength(match.ListPrefix), CodeCommentHelper.Spacer));
-									// This is just padding and not a word.
-									_isFirstWord = true;
+                                    // This is just padding and not a word.
+                                    _isFirstWord = true;
                                 }
                             }
 


### PR DESCRIPTION
This pull request includes fixes for #90 and #106. Added extra unit tests to test these cases, and found no regression on any of the previous functionality.

Sadly I had a bit of a fight with Visual Studio version differences and whitespace handling, this marks some files as changed even though they really aren't.