### PR TITLE
Fix splitting of XML comment tags which contain a single <para> element.

### DIFF
--- a/CodeMaid.UnitTests/Formatting/XmlFormattingTests.cs
+++ b/CodeMaid.UnitTests/Formatting/XmlFormattingTests.cs
@@ -205,6 +205,19 @@ namespace SteveCadwallader.CodeMaid.UnitTests.Formatting
 
         [TestMethod]
         [TestCategory("Formatting UnitTests")]
+        public void XmlFormattingTests_SplitsTagsWhenItContainsElementOnSeparateLine()
+        {
+            var input = "<test><para>Lorem ipsum.</para></test>";
+            var expected =
+                "<test>" + Environment.NewLine +
+                "<para>Lorem ipsum.</para>" + Environment.NewLine +
+                "</test>";
+
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected);
+        }
+
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
         public void XmlFormattingTests_TagNameKeepCase()
         {
             var input = "<Summary></Summary>";

--- a/CodeMaid/Model/Comments/CommentFormatter.cs
+++ b/CodeMaid/Model/Comments/CommentFormatter.cs
@@ -156,7 +156,10 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
             var xml = line as CommentLineXml;
             if (xml != null)
             {
-                return ParseXml(xml, indentLevel);
+                ParseXml(xml, indentLevel);
+
+                // XML lines always introduce a line wrap.
+                return true;
             }
             else
             {
@@ -315,8 +318,7 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
             return false;
         }
 
-        /// <returns><c>true</c> if line fitted on single line, <c>false</c> if it wrapped on multiple lines.</returns>
-        private bool ParseXml(CommentLineXml line, int indentLevel = 0)
+        private void ParseXml(CommentLineXml line, int indentLevel = 0)
         {
             // All XML lines start on a new line.
             if (!_isFirstWord)
@@ -388,8 +390,6 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
             }
 
             Append(line.Closetag);
-
-            return tagOnOwnLine;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR makes CodeMaid format the XML comment…

```
<test><para>Lorem ipsum.</para></test>
```

…like this:

```
<test>
<para>Lorem ipsum.</para>
</test>
```

Currently, CodeMaid would format it as:

```
<test>
<para>Lorem ipsum.</para></test>
```

I also added a unit test for this case.