### PR TITLE
Add support for VisualGDB's intellisence workaround

### DIFF
--- a/CodeMaid/Helpers/CodeCommentHelper.cs
+++ b/CodeMaid/Helpers/CodeCommentHelper.cs
@@ -110,6 +110,7 @@ namespace SteveCadwallader.CodeMaid.Helpers
             switch (language)
             {
                 case "C/C++":
+                case "C/C++ (VisualGDB)":
                 case "CSharp":
                 case "CSS":
                 case "F#":

--- a/CodeMaid/Logic/Cleaning/CodeCleanupAvailabilityLogic.cs
+++ b/CodeMaid/Logic/Cleaning/CodeCleanupAvailabilityLogic.cs
@@ -203,6 +203,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
                 case "Basic": return Settings.Default.Cleaning_IncludeVB;
                 case "CSharp": return Settings.Default.Cleaning_IncludeCSharp;
                 case "C/C++": return Settings.Default.Cleaning_IncludeCPlusPlus;
+                case "C/C++ (VisualGDB)": return Settings.Default.Cleaning_IncludeCPlusPlus;
                 case "CSS": return Settings.Default.Cleaning_IncludeCSS;
                 case "F#": return Settings.Default.Cleaning_IncludeFSharp;
                 case "HTML":

--- a/CodeMaid/Logic/Cleaning/CodeCleanupManager.cs
+++ b/CodeMaid/Logic/Cleaning/CodeCleanupManager.cs
@@ -209,6 +209,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
                     return RunCodeCleanupCSharp;
 
                 case "C/C++":
+                case "C/C++ (VisualGDB)":
                 case "CSS":
                 case "JavaScript":
                 case "JScript":

--- a/CodeMaid/Logic/Cleaning/RemoveWhitespaceLogic.cs
+++ b/CodeMaid/Logic/Cleaning/RemoveWhitespaceLogic.cs
@@ -195,7 +195,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
             if (cursor.AtEndOfDocument && cursor.AtStartOfLine && cursor.AtEndOfLine)
             {
                 // Make an exception for C++ resource files to work-around known EOF issue: http://connect.microsoft.com/VisualStudio/feedback/details/173903/resource-compiler-returns-a-rc1004-unexpected-eof-found-error#details
-                if (textDocument.Language == "C/C++" &&
+                if ((textDocument.Language == "C/C++" || textDocument.Language == "C/C++ (VisualGDB)") &&
                     (textDocument.Parent.FullName.EndsWith(".h") || textDocument.Parent.FullName.EndsWith(".rc2")))
                 {
                     return;


### PR DESCRIPTION
VisualGDB reports *.c and *.cpp files' language as "C/C++ (VisualGDB)" and not "C/C++" if CLang intellisence is used.