### PR TITLE
Added safety check for StructLayout in CodeReorganizationAvailablityLogic

### DIFF
--- a/CodeMaid/Logic/Reorganizing/CodeReorganizationAvailabilityLogic.cs
+++ b/CodeMaid/Logic/Reorganizing/CodeReorganizationAvailabilityLogic.cs
@@ -64,7 +64,8 @@ namespace SteveCadwallader.CodeMaid.Logic.Reorganizing
                    document != null &&
                    document.GetCodeLanguage() == CodeLanguage.CSharp &&
                    !document.IsExternal() &&
-                   !HasPreprocessorConditionalCompilationDirectives(document);
+                   !HasPreprocessorConditionalCompilationDirectives(document) &&
+                   !HasStructLayoutAttribute(document);
         }
 
         #endregion Internal Methods
@@ -90,6 +91,21 @@ namespace SteveCadwallader.CodeMaid.Logic.Reorganizing
                 }
             }
 
+            return false;
+        }
+
+        private bool HasStructLayoutAttribute(Document document)
+        {
+            var textDocument = document.GetTextDocument();
+            if (textDocument != null)
+            {
+                const string pattern = @"^[ \t]*\[[ \t]*StructLayout\(";
+                var editPoint = TextDocumentHelper.FirstOrDefaultMatch(textDocument, pattern);
+                if (editPoint != null)
+                {
+                    return true;
+                }
+            }
             return false;
         }
 


### PR DESCRIPTION
Related to issue #239.

Required to prevent re-organization of structs or classes that are meant to be marshalled to a Native function (Order is important).

	[StructLayout(LayoutKind.Sequential)]
	public struct Example
	{
		int var1;
		int var3; //needs to stay above var2
		int var2;
	}