### PR TITLE
Speed up reorganization by a gazillion times

### DIFF
--- a/CodeMaid/Helpers/CodeCommentHelper.cs
+++ b/CodeMaid/Helpers/CodeCommentHelper.cs
@@ -141,7 +141,7 @@ namespace SteveCadwallader.CodeMaid.Helpers
             }
 
             var pattern = string.Format(@"^{0}(?<line>(?<indent>[\t ]*)(?<listprefix>[-=\*\+]+[ \t]*|\w+[\):][ \t]+|\d+\.[ \t]+)?((?<words>[^\t\r\n ]+)*[\t ]*)*)[\r]*[\n]?$", prefix);
-            return new Regex(pattern, RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.Multiline);
+            return new Regex(pattern, RegexOptions.ExplicitCapture | RegexOptions.Multiline);
         }
 
         internal static int GetTabSize(CodeMaidPackage package, TextDocument document)


### PR DESCRIPTION
Previously, the regex to detect comments had the "Compile" flag enabled. Since each instance of the regex was only used once, this compiling could happen hundreds of times with a sufficiently large code file, which was super-bad for performance.

When the compile flag is removed, the reorganization time drops from potentially 10s of seconds to 1-2 seconds.

What we could do later, is compile the regex again, but lazily cache it somewhere, so only a single instance is ever reused, which could make the reorganization process even faster.