### PR TITLE
Explicit interface order

### DIFF
--- a/CodeMaid.UnitTests/CodeMaid.UnitTests.csproj
+++ b/CodeMaid.UnitTests/CodeMaid.UnitTests.csproj
@@ -80,10 +80,34 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\Microsoft.VSSDK.UnitTestLibrary.dll</HintPath>
     </Reference>
+    <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Design" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="EnvDTE">
+      <Guid>{80CC9F66-E7D8-4DDD-85B6-D9E6CD0E93E2}</Guid>
+      <VersionMajor>8</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>primary</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </COMReference>
+    <COMReference Include="EnvDTE80">
+      <Guid>{1A31287A-4D7D-413E-8E32-3B374931BD89}</Guid>
+      <VersionMajor>8</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>primary</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </COMReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GlobalAssemblyInfo.cs">
@@ -97,6 +121,7 @@
     <Compile Include="Formatting\SimpleFormattingTests.cs" />
     <Compile Include="Formatting\XmlFormattingTests.cs" />
     <Compile Include="Formatting\ListFormattingTests.cs" />
+    <Compile Include="Helpers\CodeItemTypeComparerTests.cs" />
     <Compile Include="Helpers\CodeMaidPackageHelper.cs" />
     <Compile Include="Helpers\UIShellServiceMock.cs" />
     <Compile Include="Helpers\WindowFrameMock.cs" />
@@ -116,6 +141,7 @@
       <Link>Properties\CodeMaid.snk</Link>
     </None>
     <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/CodeMaid.UnitTests/Helpers/CodeItemTypeComparerTests.cs
+++ b/CodeMaid.UnitTests/Helpers/CodeItemTypeComparerTests.cs
@@ -3,12 +3,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using SteveCadwallader.CodeMaid.Helpers;
 using SteveCadwallader.CodeMaid.Model.CodeItems;
+using SteveCadwallader.CodeMaid.Properties;
 
 namespace SteveCadwallader.CodeMaid.UnitTests.Helpers
 {
     [TestClass]
     public class CodeItemTypeComparerTests
     {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            Settings.Default.Reset();
+        }
+
         [TestMethod]
         public void ShouldSortItemsOfTheSameTypeByName()
         {
@@ -48,11 +55,25 @@ namespace SteveCadwallader.CodeMaid.UnitTests.Helpers
         [TestMethod]
         public void ShouldSortByExplicitInterfaceMemberName()
         {
-            CodeItemMethod methodB = CreateExplicitMethod("Interface", "Z", 1);
-            BaseCodeItem methodA = Create<CodeItemMethod>("X", 2);
+            CodeItemMethod methodZ = CreateExplicitMethod("Interface", "Z", 1);
+            BaseCodeItem methodX = Create<CodeItemMethod>("X", 2);
             var comparer = new CodeItemTypeComparer(sortByName: true);
 
-            int result = comparer.Compare(methodA, methodB);
+            Settings.Default.Reorganizing_ExplicitMembersAtEnd = false;
+            int result = comparer.Compare(methodX, methodZ);
+
+            Assert.IsTrue(result < 0);
+        }
+
+        [TestMethod]
+        public void ShouldPlaceExplicitInterfaceMembersAtTheEndOfTheGroup()
+        {
+            CodeItemMethod methodA = CreateExplicitMethod("Interface", "A", 1);
+            BaseCodeItem methodB = Create<CodeItemMethod>("B", 2);
+            var comparer = new CodeItemTypeComparer(sortByName: true);
+
+            Settings.Default.Reorganizing_ExplicitMembersAtEnd = true;
+            int result = comparer.Compare(methodB, methodA);
 
             Assert.IsTrue(result < 0);
         }

--- a/CodeMaid.UnitTests/Helpers/CodeItemTypeComparerTests.cs
+++ b/CodeMaid.UnitTests/Helpers/CodeItemTypeComparerTests.cs
@@ -1,0 +1,77 @@
+﻿using EnvDTE80;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using SteveCadwallader.CodeMaid.Helpers;
+using SteveCadwallader.CodeMaid.Model.CodeItems;
+
+namespace SteveCadwallader.CodeMaid.UnitTests.Helpers
+{
+    [TestClass]
+    public class CodeItemTypeComparerTests
+    {
+        [TestMethod]
+        public void ShouldSortItemsOfTheSameTypeByName()
+        {
+            BaseCodeItem itemB = Create<CodeItemField>("b", 1);
+            BaseCodeItem itemA = Create<CodeItemField>("a", 2);
+            var comparer = new CodeItemTypeComparer(sortByName: true);
+
+            int result = comparer.Compare(itemA, itemB);
+
+            Assert.IsTrue(result < 0);
+        }
+
+        [TestMethod]
+        public void ShouldSortItemsOfTheSameTypeByOffset()
+        {
+            BaseCodeItem itemB = Create<CodeItemField>("b", 1);
+            BaseCodeItem itemA = Create<CodeItemField>("a", 2);
+            var comparer = new CodeItemTypeComparer(sortByName: false);
+
+            int result = comparer.Compare(itemA, itemB);
+
+            Assert.IsTrue(result > 0);
+        }
+
+        [TestMethod]
+        public void ShouldSortByGroupType()
+        {
+            BaseCodeItem method = Create<CodeItemMethod>("a", 1);
+            BaseCodeItem field = Create<CodeItemField>("z", 2);
+            var comparer = new CodeItemTypeComparer(sortByName: true);
+
+            int result = comparer.Compare(field, method);
+
+            Assert.IsTrue(result < 0);
+        }
+
+        [TestMethod]
+        public void ShouldSortByExplicitInterfaceMemberName()
+        {
+            CodeItemMethod methodB = CreateExplicitMethod("Interface", "Z", 1);
+            BaseCodeItem methodA = Create<CodeItemMethod>("X", 2);
+            var comparer = new CodeItemTypeComparer(sortByName: true);
+
+            int result = comparer.Compare(methodA, methodB);
+
+            Assert.IsTrue(result < 0);
+        }
+
+        private static T Create<T>(string name, int offset) where T : BaseCodeItem, new()
+        {
+            return new T
+            {
+                Name = name,
+                StartOffset = offset
+            };
+        }
+
+        private static CodeItemMethod CreateExplicitMethod(string interfaceName, string methodName, int offset)
+        {
+            CodeItemMethod method = Create<CodeItemMethod>(interfaceName + "." + methodName, offset);
+            method.CodeFunction = Substitute.For<CodeFunction2>();
+            method.CodeFunction.Name = method.Name;
+            return method;
+        }
+    }
+}

--- a/CodeMaid.UnitTests/packages.config
+++ b/CodeMaid.UnitTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
+</packages>

--- a/CodeMaid/CodeMaid.csproj
+++ b/CodeMaid/CodeMaid.csproj
@@ -206,6 +206,7 @@
     <Compile Include="Logic\Reorganizing\CodeReorganizationAvailabilityLogic.cs" />
     <Compile Include="Logic\Reorganizing\GenerateRegionLogic.cs" />
     <Compile Include="Logic\Reorganizing\RegionComparerByName.cs" />
+    <Compile Include="Model\CodeItems\IInterfaceItem.cs" />
     <Compile Include="Model\Comments\CommentLine.cs" />
     <Compile Include="Model\Comments\CommentLineXml.cs" />
     <Compile Include="Model\Comments\ICommentLine.cs" />

--- a/CodeMaid/Helpers/CodeItemTypeComparer.cs
+++ b/CodeMaid/Helpers/CodeItemTypeComparer.cs
@@ -70,6 +70,7 @@ namespace SteveCadwallader.CodeMaid.Helpers
         {
             int typeOffset = CalculateTypeOffset(codeItem);
             int accessOffset = CalculateAccessOffset(codeItem);
+            int explicitOffset = CalculateExplicitInterfaceOffset(codeItem);
             int constantOffset = CalculateConstantOffset(codeItem);
             int staticOffset = CalculateStaticOffset(codeItem);
             int readOnlyOffset = CalculateReadOnlyOffset(codeItem);
@@ -78,16 +79,16 @@ namespace SteveCadwallader.CodeMaid.Helpers
 
             if (!Settings.Default.Reorganizing_PrimaryOrderByAccessLevel)
             {
-                calc += typeOffset * 10000;
-                calc += accessOffset * 1000;
+                calc += typeOffset * 100000;
+                calc += accessOffset * 10000;
             }
             else
             {
-                calc += accessOffset * 10000;
-                calc += typeOffset * 1000;
+                calc += accessOffset * 100000;
+                calc += typeOffset * 10000;
             }
 
-            calc += (constantOffset * 100) + (staticOffset * 10) + readOnlyOffset;
+            calc += (explicitOffset * 1000) + (constantOffset * 100) + (staticOffset * 10) + readOnlyOffset;
 
             return calc;
         }
@@ -135,6 +136,20 @@ namespace SteveCadwallader.CodeMaid.Helpers
             if (codeItemField == null) return 0;
 
             return codeItemField.IsConstant ? 0 : 1;
+        }
+
+        private static int CalculateExplicitInterfaceOffset(BaseCodeItem codeItem)
+        {
+            if (Settings.Default.Reorganizing_ExplicitMembersAtEnd)
+            {
+                var interfaceItem = codeItem as IInterfaceItem;
+                if ((interfaceItem != null) && interfaceItem.IsExplicitInterfaceImplementation)
+                {
+                    return 1;
+                }
+            }
+
+            return 0;
         }
 
         private static int CalculateStaticOffset(BaseCodeItem codeItem)

--- a/CodeMaid/Helpers/CodeItemTypeComparer.cs
+++ b/CodeMaid/Helpers/CodeItemTypeComparer.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
 using EnvDTE;
 using SteveCadwallader.CodeMaid.Model.CodeItems;
 using SteveCadwallader.CodeMaid.Properties;
+using System.Collections.Generic;
 
 namespace SteveCadwallader.CodeMaid.Helpers
 {
@@ -130,14 +130,6 @@ namespace SteveCadwallader.CodeMaid.Helpers
             }
         }
 
-        private static int CalculateConstantOffset(BaseCodeItem codeItem)
-        {
-            var codeItemField = codeItem as CodeItemField;
-            if (codeItemField == null) return 0;
-
-            return codeItemField.IsConstant ? 0 : 1;
-        }
-
         private static int CalculateExplicitInterfaceOffset(BaseCodeItem codeItem)
         {
             if (Settings.Default.Reorganizing_ExplicitMembersAtEnd)
@@ -150,6 +142,14 @@ namespace SteveCadwallader.CodeMaid.Helpers
             }
 
             return 0;
+        }
+
+        private static int CalculateConstantOffset(BaseCodeItem codeItem)
+        {
+            var codeItemField = codeItem as CodeItemField;
+            if (codeItemField == null) return 0;
+
+            return codeItemField.IsConstant ? 0 : 1;
         }
 
         private static int CalculateStaticOffset(BaseCodeItem codeItem)
@@ -176,7 +176,7 @@ namespace SteveCadwallader.CodeMaid.Helpers
             {
                 // Try to find where the interface ends and the method starts
                 int dot = name.LastIndexOf('.') + 1;
-                if ((dot > 0) && (dot < name.Length))
+                if (0 < dot && dot < name.Length)
                 {
                     return name.Substring(dot);
                 }

--- a/CodeMaid/Logic/Reorganizing/CodeReorganizationManager.cs
+++ b/CodeMaid/Logic/Reorganizing/CodeReorganizationManager.cs
@@ -364,9 +364,8 @@ namespace SteveCadwallader.CodeMaid.Logic.Reorganizing
 
             // Get the items in their current order and their desired order.
             var currentOrder = GetReorganizableCodeItemElements(codeItems);
-            var desiredOrder = currentOrder.OrderBy(CodeItemTypeComparer.CalculateNumericRepresentation)
-                                           .ThenBy(x => Settings.Default.Reorganizing_AlphabetizeMembersOfTheSameGroup ? (object)x.Name : (object)x.StartOffset)
-                                           .ToList();
+            var desiredOrder = new List<BaseCodeItemElement>(currentOrder);
+            desiredOrder.Sort(new CodeItemTypeComparer(Settings.Default.Reorganizing_AlphabetizeMembersOfTheSameGroup));
 
             // Iterate across the items in the desired order, moving them when necessary.
             for (int desiredIndex = 0; desiredIndex < desiredOrder.Count; desiredIndex++)

--- a/CodeMaid/Model/CodeItems/CodeItemEvent.cs
+++ b/CodeMaid/Model/CodeItems/CodeItemEvent.cs
@@ -8,7 +8,7 @@ namespace SteveCadwallader.CodeMaid.Model.CodeItems
     /// <summary>
     /// The representation of a code event.
     /// </summary>
-    public class CodeItemEvent : BaseCodeItemElement
+    public class CodeItemEvent : BaseCodeItemElement, IInterfaceItem
     {
         #region Fields
 

--- a/CodeMaid/Model/CodeItems/CodeItemMethod.cs
+++ b/CodeMaid/Model/CodeItems/CodeItemMethod.cs
@@ -10,7 +10,7 @@ namespace SteveCadwallader.CodeMaid.Model.CodeItems
     /// <summary>
     /// The representation of a code method.
     /// </summary>
-    public class CodeItemMethod : BaseCodeItemElement, ICodeItemComplexity, ICodeItemParameters
+    public class CodeItemMethod : BaseCodeItemElement, ICodeItemComplexity, ICodeItemParameters, IInterfaceItem
     {
         #region Fields
 

--- a/CodeMaid/Model/CodeItems/CodeItemProperty.cs
+++ b/CodeMaid/Model/CodeItems/CodeItemProperty.cs
@@ -10,7 +10,7 @@ namespace SteveCadwallader.CodeMaid.Model.CodeItems
     /// <summary>
     /// The representation of a code property.
     /// </summary>
-    public class CodeItemProperty : BaseCodeItemElement, ICodeItemComplexity, ICodeItemParameters
+    public class CodeItemProperty : BaseCodeItemElement, ICodeItemComplexity, ICodeItemParameters, IInterfaceItem
     {
         #region Fields
 

--- a/CodeMaid/Model/CodeItems/IInterfaceItem.cs
+++ b/CodeMaid/Model/CodeItems/IInterfaceItem.cs
@@ -1,0 +1,13 @@
+﻿namespace SteveCadwallader.CodeMaid.Model.CodeItems
+{
+    /// <summary>
+    /// Represents an item that can implement an interface member.
+    /// </summary>
+    public interface IInterfaceItem
+    {
+        /// <summary>
+        /// Gets a flag indicating if this is an explicit interface implementation.
+        /// </summary>
+        bool IsExplicitInterfaceImplementation { get; }
+    }
+}

--- a/CodeMaid/Model/CodeTree/CodeTreeBuilder.cs
+++ b/CodeMaid/Model/CodeTree/CodeTreeBuilder.cs
@@ -1,5 +1,6 @@
 using SteveCadwallader.CodeMaid.Helpers;
 using SteveCadwallader.CodeMaid.Model.CodeItems;
+using SteveCadwallader.CodeMaid.Properties;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -155,7 +156,7 @@ namespace SteveCadwallader.CodeMaid.Model.CodeTree
                 organizedCodeItems.AddRange(structuredCodeItems);
 
                 // Sort the list of code items by type recursively.
-                RecursivelySort(organizedCodeItems, new CodeItemTypeComparer());
+                RecursivelySort(organizedCodeItems, new CodeItemTypeComparer(Settings.Default.Digging_SecondarySortTypeByName));
 
                 // Group the list of code items by type recursively.
                 foreach (var codeItem in organizedCodeItems.OfType<ICodeItemParent>())

--- a/CodeMaid/Properties/Settings.Designer.cs
+++ b/CodeMaid/Properties/Settings.Designer.cs
@@ -1681,6 +1681,18 @@ namespace SteveCadwallader.CodeMaid.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool Reorganizing_ExplicitMembersAtEnd {
+            get {
+                return ((bool)(this["Reorganizing_ExplicitMembersAtEnd"]));
+            }
+            set {
+                this["Reorganizing_ExplicitMembersAtEnd"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool Reorganizing_KeepMembersWithinRegions {
             get {

--- a/CodeMaid/Properties/Settings.settings
+++ b/CodeMaid/Properties/Settings.settings
@@ -416,6 +416,9 @@
     <Setting Name="Reorganizing_AlphabetizeMembersOfTheSameGroup" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="Reorganizing_ExplicitMembersAtEnd" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="Reorganizing_KeepMembersWithinRegions" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>

--- a/CodeMaid/UI/Dialogs/Options/Reorganizing/ReorganizingGeneralDataTemplate.xaml
+++ b/CodeMaid/UI/Dialogs/Options/Reorganizing/ReorganizingGeneralDataTemplate.xaml
@@ -9,6 +9,7 @@
                 <StackPanel>
                     <CheckBox Content="Alphabetize members of the same group" IsChecked="{Binding AlphabetizeMembersOfTheSameGroup}" />
                     <CheckBox Content="Keep members within regions" IsChecked="{Binding KeepMembersWithinRegions}" />
+                    <CheckBox Content="Place explicit interface members at the end of their group" IsChecked="{Binding ExplicitInterfaceMembersAtTheEnd}" />
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="Primary ordering should be by" VerticalAlignment="Center" />
                         <RadioButton Content="type then access" IsChecked="{Binding PrimaryOrderByAccessLevel, Converter={x:Static cnv:BooleanInverseConverter.Default}}" />

--- a/CodeMaid/UI/Dialogs/Options/Reorganizing/ReorganizingGeneralViewModel.cs
+++ b/CodeMaid/UI/Dialogs/Options/Reorganizing/ReorganizingGeneralViewModel.cs
@@ -21,6 +21,7 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.Reorganizing
             Mappings = new SettingsToOptionsList(ActiveSettings, this)
             {
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Reorganizing_AlphabetizeMembersOfTheSameGroup, x => AlphabetizeMembersOfTheSameGroup),
+                new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Reorganizing_ExplicitMembersAtEnd, x => ExplicitInterfaceMembersAtTheEnd),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Reorganizing_KeepMembersWithinRegions, x => KeepMembersWithinRegions),
                 new SettingToOptionMapping<int, AskYesNo>(x => ActiveSettings.Reorganizing_PerformWhenPreprocessorConditionals, x => PerformWhenPreprocessorConditionals),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Reorganizing_PrimaryOrderByAccessLevel, x => PrimaryOrderByAccessLevel),
@@ -45,6 +46,15 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.Reorganizing
         /// Gets or sets the flag indicating if members of the same group should be alphabetized.
         /// </summary>
         public bool AlphabetizeMembersOfTheSameGroup
+        {
+            get { return GetPropertyValue<bool>(); }
+            set { SetPropertyValue(value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the flag indicating if explicit interface members should be placed at the end of the group.
+        /// </summary>
+        public bool ExplicitInterfaceMembersAtTheEnd
         {
             get { return GetPropertyValue<bool>(); }
             set { SetPropertyValue(value); }

--- a/CodeMaid/app.config
+++ b/CodeMaid/app.config
@@ -545,6 +545,9 @@
       <setting name="ThirdParty_UseXAMLStylerCleanup" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="Reorganizing_ExplicitMembersAtEnd" serializeAs="String">
+        <value>False</value>
+      </setting>
     </SteveCadwallader.CodeMaid.Properties.Settings>
   </userSettings>
   <startup>

--- a/CodeMaid/app.config
+++ b/CodeMaid/app.config
@@ -469,6 +469,9 @@
         serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="Reorganizing_ExplicitMembersAtEnd" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="Reorganizing_KeepMembersWithinRegions" serializeAs="String">
         <value>True</value>
       </setting>
@@ -543,9 +546,6 @@
         <value>False</value>
       </setting>
       <setting name="ThirdParty_UseXAMLStylerCleanup" serializeAs="String">
-        <value>False</value>
-      </setting>
-      <setting name="Reorganizing_ExplicitMembersAtEnd" serializeAs="String">
         <value>False</value>
       </setting>
     </SteveCadwallader.CodeMaid.Properties.Settings>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ assembly_info:
   assembly_informational_version: '{version}'
 
 before_build:
+  - nuget restore
   - ps: Vsix-IncrementVsixVersion | Vsix-UpdateBuildVersion
   - ps: Vsix-TokenReplacement CodeMaid\source.extension.cs 'Version = "([0-9\\.]+)"' 'Version = "{version}"'
 


### PR DESCRIPTION
Here's my attempt at fixing issue #315 and adding the ability to place explicit interface members after normal public methods.

Note I've added a dependency on NSubstitute (via NuGet) for the unit tests - I'm happy to change that to another mocking framework if you have a preference.