### PR TITLE
Now adds <doc> root tag if it doesn't exist

### DIFF
--- a/CodeMaid/UI/Converters/DocCommentToStringConverter.cs
+++ b/CodeMaid/UI/Converters/DocCommentToStringConverter.cs
@@ -31,6 +31,10 @@ namespace SteveCadwallader.CodeMaid.UI.Converters
 
             try
             {
+                //In VB .NET the returned XML hasn't a <doc> tag so we add it to avoid a crash with multiple documentation tags
+                if (!str.StartsWith("<doc>"))
+                    str = "<doc>" + str + "</doc>";
+
                 var xElement = XElement.Parse(str);
 
                 var summaryTag = xElement.DescendantsAndSelf("summary").FirstOrDefault();


### PR DESCRIPTION
This change tries to fix the issue [#326](https://github.com/codecadwallader/codemaid/issues/326).
I've added a condition that checks that the `<doc>` tag exists and adds it if does not exist.