### PR TITLE
Fix for issue 329: Cleanup removes consecutive blank lines in a multiline string literal.

### DIFF
--- a/CodeMaid/Logic/Cleaning/RemoveWhitespaceLogic.cs
+++ b/CodeMaid/Logic/Cleaning/RemoveWhitespaceLogic.cs
@@ -218,7 +218,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
         {
             if (!Settings.Default.Cleaning_RemoveMultipleConsecutiveBlankLines) return;
 
-            const string pattern = @"(\r?\n){3,}";
+            const string pattern = @"(?<!@""(""""|[^""])*)(\r?\n){3,}";
             string replacement = Environment.NewLine + Environment.NewLine;
 
             TextDocumentHelper.SubstituteAllStringMatches(textDocument, pattern, replacement);


### PR DESCRIPTION
I just tweaked the regex for 3+ newlines to do a look-behind assertion in order to ensure that it is not inside of an un-terminated verbatim string literal.
