### PR TITLE
#393: Add ability to clear solution explorer search before finding.

### DIFF
--- a/CodeMaid/CodeMaidPackage.cs
+++ b/CodeMaid/CodeMaidPackage.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Threading;
+using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace SteveCadwallader.CodeMaid
 {
@@ -67,6 +68,11 @@ namespace SteveCadwallader.CodeMaid
         /// The top level application instance of the VS IDE that is executing this package.
         /// </summary>
         private DTE2 _ide;
+
+        /// <summary>
+        /// The service provider.
+        /// </summary>
+        private IServiceProvider _serviceProvider;
 
         /// <summary>
         /// The Spade tool window.
@@ -159,6 +165,11 @@ namespace SteveCadwallader.CodeMaid
         /// Gets the menu command service.
         /// </summary>
         public OleMenuCommandService MenuCommandService => GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
+
+        /// <summary>
+        /// Gets the service provider.
+        /// </summary>
+        public IServiceProvider ServiceProvider => _serviceProvider ?? (_serviceProvider = new ServiceProvider((IServiceProvider)IDE));
 
         /// <summary>
         /// Gets the Spade tool window, iff it already exists.

--- a/CodeMaid/CodeMaidPackage.cs
+++ b/CodeMaid/CodeMaidPackage.cs
@@ -22,7 +22,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Threading;
-using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace SteveCadwallader.CodeMaid
 {
@@ -169,7 +168,7 @@ namespace SteveCadwallader.CodeMaid
         /// <summary>
         /// Gets the service provider.
         /// </summary>
-        public IServiceProvider ServiceProvider => _serviceProvider ?? (_serviceProvider = new ServiceProvider((IServiceProvider)IDE));
+        public IServiceProvider ServiceProvider => _serviceProvider ?? (_serviceProvider = new ServiceProvider((Microsoft.VisualStudio.OLE.Interop.IServiceProvider)IDE));
 
         /// <summary>
         /// Gets the Spade tool window, iff it already exists.

--- a/CodeMaid/Integration/Commands/FindInSolutionExplorerCommand.cs
+++ b/CodeMaid/Integration/Commands/FindInSolutionExplorerCommand.cs
@@ -18,7 +18,6 @@ namespace SteveCadwallader.CodeMaid.Integration.Commands
         #region Fields
 
         private readonly CommandHelper _commandHelper;
-        private readonly ServiceProvider _serviceProvider;
 
         #endregion Fields
 
@@ -33,7 +32,6 @@ namespace SteveCadwallader.CodeMaid.Integration.Commands
                    new CommandID(PackageGuids.GuidCodeMaidCommandFindInSolutionExplorer, PackageIds.CmdIDCodeMaidFindInSolutionExplorer))
         {
             _commandHelper = CommandHelper.GetInstance(package);
-            _serviceProvider = new ServiceProvider((IServiceProvider)package.IDE);
         }
 
         #endregion Constructors
@@ -98,9 +96,12 @@ namespace SteveCadwallader.CodeMaid.Integration.Commands
         /// </summary>
         private void ClearSolutionExplorerSearchFilter()
         {
-            var solutionExplorer = VsShellUtilities.GetUIHierarchyWindow(_serviceProvider, VSConstants.StandardToolWindows.SolutionExplorer);
-            var ws = solutionExplorer as IVsWindowSearch;
-            ws?.ClearSearch();
+            if (Package.ServiceProvider != null)
+            {
+                var solutionExplorer = VsShellUtilities.GetUIHierarchyWindow(Package.ServiceProvider, VSConstants.StandardToolWindows.SolutionExplorer);
+                var ws = solutionExplorer as IVsWindowSearch;
+                ws?.ClearSearch();
+            }
         }
 
         /// <summary>

--- a/CodeMaid/Integration/Commands/FindInSolutionExplorerCommand.cs
+++ b/CodeMaid/Integration/Commands/FindInSolutionExplorerCommand.cs
@@ -1,12 +1,12 @@
 using EnvDTE;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using SteveCadwallader.CodeMaid.Helpers;
 using SteveCadwallader.CodeMaid.Properties;
 using System;
 using System.ComponentModel.Design;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Shell;
 using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
-using Microsoft.VisualStudio;
 
 namespace SteveCadwallader.CodeMaid.Integration.Commands
 {
@@ -93,7 +93,8 @@ namespace SteveCadwallader.CodeMaid.Integration.Commands
         #region Methods
 
         /// <summary>
-        /// Clears any exising search filtering in the solution explorer so that items not matching the query can be found 
+        /// Clears any exising search filtering in the solution explorer so that items not matching
+        /// the query can be found.
         /// </summary>
         private void ClearSolutionExplorerSearchFilter()
         {

--- a/CodeMaid/Logic/Digging/OutliningSynchronizationManager.cs
+++ b/CodeMaid/Logic/Digging/OutliningSynchronizationManager.cs
@@ -10,7 +10,6 @@ using SteveCadwallader.CodeMaid.Model.CodeItems;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
 namespace SteveCadwallader.CodeMaid.Logic.Digging
 {
@@ -25,7 +24,6 @@ namespace SteveCadwallader.CodeMaid.Logic.Digging
         private readonly CodeMaidPackage _package;
         private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
         private readonly IOutliningManagerService _outliningManagerService;
-        private readonly ServiceProvider _serviceProvider;
 
         private Document _document;
         private IOutliningManager _outliningManager;
@@ -48,7 +46,6 @@ namespace SteveCadwallader.CodeMaid.Logic.Digging
             // Retrieve services needed for outlining from the package.
             _editorAdaptersFactoryService = _package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
             _outliningManagerService = _package.ComponentModel.GetService<IOutliningManagerService>();
-            _serviceProvider = new ServiceProvider((IServiceProvider)_package.IDE);
         }
 
         #endregion Constructors
@@ -277,7 +274,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Digging
         /// <returns>The associated text view, otherwise null.</returns>
         private IVsTextView GetTextView(Document document)
         {
-            if (_serviceProvider == null || document == null)
+            if (_package.ServiceProvider == null || document == null)
             {
                 return null;
             }
@@ -286,7 +283,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Digging
             uint itemID;
             IVsWindowFrame windowFrame;
 
-            if (VsShellUtilities.IsDocumentOpen(_serviceProvider, document.FullName, Guid.Empty, out hierarchy, out itemID, out windowFrame))
+            if (VsShellUtilities.IsDocumentOpen(_package.ServiceProvider, document.FullName, Guid.Empty, out hierarchy, out itemID, out windowFrame))
             {
                 return VsShellUtilities.GetTextView(windowFrame);
             }

--- a/CodeMaid/Properties/Settings.Designer.cs
+++ b/CodeMaid/Properties/Settings.Designer.cs
@@ -1354,7 +1354,22 @@ namespace SteveCadwallader.CodeMaid.Properties {
                 this["Digging_SynchronizeOutlining"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool Finding_ClearSolutionExplorerSearch
+        {
+            get
+            {
+                return ((bool)(this["Finding_ClearSolutionExplorerSearch"]));
+            }
+            set
+            {
+                this["Finding_ClearSolutionExplorerSearch"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]

--- a/CodeMaid/Properties/Settings.settings
+++ b/CodeMaid/Properties/Settings.settings
@@ -335,6 +335,9 @@
     <Setting Name="Digging_SynchronizeOutlining" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="Finding_ClearSolutionExplorerSearch" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="Finding_TemporarilyOpenSolutionFolders" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
@@ -486,9 +489,6 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="ThirdParty_UseXAMLStylerCleanup" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
-    </Setting>
-    <Setting Name="Finding_ClearSolutionExplorerSearch" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
   </Settings>

--- a/CodeMaid/Properties/Settings.settings
+++ b/CodeMaid/Properties/Settings.settings
@@ -488,5 +488,8 @@
     <Setting Name="ThirdParty_UseXAMLStylerCleanup" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="Finding_ClearSolutionExplorerSearch" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/CodeMaid/UI/Dialogs/Options/Finding/FindingDataTemplate.xaml
+++ b/CodeMaid/UI/Dialogs/Options/Finding/FindingDataTemplate.xaml
@@ -3,6 +3,7 @@
         xmlns:local="clr-namespace:SteveCadwallader.CodeMaid.UI.Dialogs.Options.Finding">
     <DataTemplate DataType="{x:Type local:FindingViewModel}">
         <StackPanel>
+            <CheckBox Content="Clear Solution Explorer search filtering to find filtered items" IsChecked="{Binding ClearSolutionExplorerSearch}" />
             <CheckBox Content="Temporarily open solution folders to find nested items" IsChecked="{Binding TemporarilyOpenSolutionFolders}" />
         </StackPanel>
     </DataTemplate>

--- a/CodeMaid/UI/Dialogs/Options/Finding/FindingViewModel.cs
+++ b/CodeMaid/UI/Dialogs/Options/Finding/FindingViewModel.cs
@@ -19,7 +19,8 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.Finding
         {
             Mappings = new SettingsToOptionsList(ActiveSettings, this)
             {
-                new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Finding_TemporarilyOpenSolutionFolders, x => TemporarilyOpenSolutionFolders)
+                new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Finding_TemporarilyOpenSolutionFolders, x => TemporarilyOpenSolutionFolders),
+                new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Finding_ClearSolutionExplorerSearch, x => ClearSolutionExplorerSearch)
             };
         }
 
@@ -40,6 +41,15 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.Finding
         /// Gets or sets a flag indicating if solution folders should be temporarily opened.
         /// </summary>
         public bool TemporarilyOpenSolutionFolders
+        {
+            get { return GetPropertyValue<bool>(); }
+            set { SetPropertyValue(value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a flag indicating if Solution Explorer search should be cleared.
+        /// </summary>
+        public bool ClearSolutionExplorerSearch
         {
             get { return GetPropertyValue<bool>(); }
             set { SetPropertyValue(value); }

--- a/CodeMaid/UI/Dialogs/Options/Finding/FindingViewModel.cs
+++ b/CodeMaid/UI/Dialogs/Options/Finding/FindingViewModel.cs
@@ -19,8 +19,8 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.Finding
         {
             Mappings = new SettingsToOptionsList(ActiveSettings, this)
             {
-                new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Finding_TemporarilyOpenSolutionFolders, x => TemporarilyOpenSolutionFolders),
-                new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Finding_ClearSolutionExplorerSearch, x => ClearSolutionExplorerSearch)
+                new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Finding_ClearSolutionExplorerSearch, x => ClearSolutionExplorerSearch),
+                new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Finding_TemporarilyOpenSolutionFolders, x => TemporarilyOpenSolutionFolders)
             };
         }
 
@@ -38,18 +38,18 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.Finding
         #region Options
 
         /// <summary>
-        /// Gets or sets a flag indicating if solution folders should be temporarily opened.
+        /// Gets or sets a flag indicating if Solution Explorer search should be cleared.
         /// </summary>
-        public bool TemporarilyOpenSolutionFolders
+        public bool ClearSolutionExplorerSearch
         {
             get { return GetPropertyValue<bool>(); }
             set { SetPropertyValue(value); }
         }
 
         /// <summary>
-        /// Gets or sets a flag indicating if Solution Explorer search should be cleared.
+        /// Gets or sets a flag indicating if solution folders should be temporarily opened.
         /// </summary>
-        public bool ClearSolutionExplorerSearch
+        public bool TemporarilyOpenSolutionFolders
         {
             get { return GetPropertyValue<bool>(); }
             set { SetPropertyValue(value); }

--- a/CodeMaid/app.config
+++ b/CodeMaid/app.config
@@ -384,6 +384,9 @@
       <setting name="Digging_SynchronizeOutlining" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="Finding_ClearSolutionExplorerSearch" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="Finding_TemporarilyOpenSolutionFolders" serializeAs="String">
         <value>True</value>
       </setting>


### PR DESCRIPTION
This solution works but has one potential drawback. Though the Solution Explorer will stop filtering items by the search query, the query string does not leave the search box. I could not find a way to make this box clear (and I am not even sure that is the behavior one would want.)