### PR TITLE
Updated reference to cleanup command for VS 15 + #416

### DIFF
--- a/CodeMaid/Logic/Cleaning/UsingStatementCleanupLogic.cs
+++ b/CodeMaid/Logic/Cleaning/UsingStatementCleanupLogic.cs
@@ -86,7 +86,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
 
             if (_package.IDEVersion >= 15)
             {
-                _commandHelper.ExecuteCommand(textDocument, "Edit.RemoveAndSort");
+                _commandHelper.ExecuteCommand(textDocument, "EditorContextMenus.CodeWindow.RemoveAndSort");
             }
             else
             {


### PR DESCRIPTION
Fix for cleanup of Usings in Visual Studio 2017 in reference to issue #416.