### PR TITLE
Undo any special logic for not showing CodeMaid in FullScreen

### DIFF
--- a/CodeMaid/CodeMaidPackage.cs
+++ b/CodeMaid/CodeMaidPackage.cs
@@ -44,7 +44,7 @@ namespace SteveCadwallader.CodeMaid
     [ProvideToolWindow(typeof(SpadeToolWindow), MultiInstances = false, Style = VsDockStyle.Tabbed, Orientation = ToolWindowOrientation.Left, Window = EnvDTE.Constants.vsWindowKindSolutionExplorer)]
     [ProvideToolWindowVisibility(typeof(SpadeToolWindow), "{F1536EF8-92EC-443C-9ED7-FDADF150DA82}")]
     [Guid(PackageGuids.GuidCodeMaidPackageString)] // Package unique GUID.
-    public sealed class CodeMaidPackage : Package, IVsInstalledProduct, IVsPackageDynamicToolOwner
+    public sealed class CodeMaidPackage : Package, IVsInstalledProduct
     {
         #region Fields
 
@@ -306,46 +306,6 @@ namespace SteveCadwallader.CodeMaid
         }
 
         #endregion IVsInstalledProduct Members
-
-        #region IVsPackageDynamicToolOwner members
-
-        /// <summary>
-        /// Allows the package to control whether the tool window should be shown or hidden. This
-        /// method is called by the shell when the user switches to a different window view or
-        /// context, for example Design, Debugging, Full Screen, etc.
-        /// </summary>
-        /// <returns>
-        /// If the method succeeds, it returns <see
-        /// cref="F:Microsoft.VisualStudio.VSConstants.S_OK"/>. If it fails, it returns an error code.
-        /// </returns>
-        /// <param name="rguidPersistenceSlot">[in] The GUID of the window.</param>
-        /// <param name="pfShowTool">[out] true to show the window, otherwise false.</param>
-        public int QueryShowTool(ref Guid rguidPersistenceSlot, out int pfShowTool)
-        {
-            pfShowTool = 1;
-
-            if (rguidPersistenceSlot == PackageGuids.GuidCodeMaidToolWindowSpade)
-            {
-                var monitorSelection = GetService(typeof(IVsMonitorSelection)) as IVsMonitorSelection;
-                if (monitorSelection != null)
-                {
-                    var guidCmdUI = VSConstants.UICONTEXT_FullScreenMode;
-                    uint dwCmdUICookie;
-                    monitorSelection.GetCmdUIContextCookie(ref guidCmdUI, out dwCmdUICookie);
-
-                    int fActive;
-                    monitorSelection.IsCmdUIContextActive(dwCmdUICookie, out fActive);
-                    if (fActive == 1)
-                    {
-                        pfShowTool = 0;
-                    }
-                }
-            }
-
-            return VSConstants.S_OK;
-        }
-
-        #endregion IVsPackageDynamicToolOwner members
 
         #region Private Methods
 


### PR DESCRIPTION
… because it would not allow the window to be shown even when the user specifically requested it.

Instead, just manually close the window when it shows up in FullScreen and VS will remember your preference next time you go full screen and won't bring up CodeMaid.
This fixes #304