### PR TITLE
ThirdParty: Fixes XAML Styler command reference for new versions of XAML Styler extension

### DIFF
--- a/CodeMaid/Logic/Cleaning/CodeCleanupManager.cs
+++ b/CodeMaid/Logic/Cleaning/CodeCleanupManager.cs
@@ -580,7 +580,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
         {
             if (!Settings.Default.ThirdParty_UseXAMLStylerCleanup) return;
 
-            _commandHelper.ExecuteCommand(textDocument, "EditorContextMenus.XAMLEditor.BeautifyXaml", "EditorContextMenus.XAMLEditor.FormatXAML");
+            _commandHelper.ExecuteCommand(textDocument, "EditorContextMenus.XAMLEditor.BeautifyXaml", "EditorContextMenus.XAMLEditor.FormatXAML", "EditorContextMenus.CodeWindow.FormatXAML");
         }
 
         /// <summary>

--- a/CodeMaid/UI/Dialogs/Options/ThirdParty/ThirdPartyViewModel.cs
+++ b/CodeMaid/UI/Dialogs/Options/ThirdParty/ThirdPartyViewModel.cs
@@ -101,7 +101,7 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.ThirdParty
         /// <summary>
         /// Gets a flag indicating if the UseXAMLStylerCleanup option should be enabled.
         /// </summary>
-        public bool IsEnabledUseXAMLStylerCleanup => _commandHelper.FindCommand("EditorContextMenus.XAMLEditor.BeautifyXaml", "EditorContextMenus.XAMLEditor.FormatXAML") != null;
+        public bool IsEnabledUseXAMLStylerCleanup => _commandHelper.FindCommand("EditorContextMenus.XAMLEditor.BeautifyXaml", "EditorContextMenus.XAMLEditor.FormatXAML", "EditorContextMenus.CodeWindow.FormatXAML") != null;
 
         #endregion Enables
     }


### PR DESCRIPTION
Fixes #401 

With Visual Studio 2017, the menu command id changed. This fix updates the list of command parameters to support newer versions of the XAML Styler extension with this new menu command id.