### PR TITLE
Ignore comment lines starting with certain prefixes

### DIFF
--- a/CodeMaid.UnitTests/CodeMaid.UnitTests.csproj
+++ b/CodeMaid.UnitTests/CodeMaid.UnitTests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Formatting\CommentFormatHelper.cs" />
     <Compile Include="Formatting\HeaderFormattingTests.cs" />
     <Compile Include="Formatting\FormatWithPrefixTests.cs" />
+    <Compile Include="Formatting\IgnorePrefixesTests.cs" />
     <Compile Include="Formatting\SimpleFormattingTests.cs" />
     <Compile Include="Formatting\XmlFormattingTests.cs" />
     <Compile Include="Formatting\ListFormattingTests.cs" />

--- a/CodeMaid.UnitTests/Formatting/CommentFormatHelper.cs
+++ b/CodeMaid.UnitTests/Formatting/CommentFormatHelper.cs
@@ -38,11 +38,7 @@ namespace SteveCadwallader.CodeMaid.UnitTests.Formatting
 
         public static string Format(string text, string prefix)
         {
-            var xml = XElement.Parse($"<doc>{text}</doc>");
-            var line = new CommentLineXml(xml);
-            var regex = CodeCommentHelper.GetCommentRegex(CodeLanguage.CSharp, !string.IsNullOrEmpty(prefix));
-            var formatter = new CommentFormatter(line, prefix, 4, regex);
-            return formatter.ToString();
+            return CodeComment.FormatXml(text, prefix);
         }
     }
 }

--- a/CodeMaid.UnitTests/Formatting/IgnorePrefixesTests.cs
+++ b/CodeMaid.UnitTests/Formatting/IgnorePrefixesTests.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SteveCadwallader.CodeMaid.Properties;
+using System;
+
+namespace SteveCadwallader.CodeMaid.UnitTests.Formatting
+{
+    /// <summary>
+    /// Test for the ignoring of comments lines starting with certain prefixes.
+    /// </summary>
+    [TestClass]
+    public class IgnorePrefixesTests
+    {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            Settings.Default.Reset();
+        }
+
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
+        public void IgnorePrefixesTests_DoesNotWrapSingleLine()
+        {
+            Settings.Default.Formatting_CommentWrapColumn = 30;
+            CommentFormatHelper.AssertEqualAfterFormat(@"TODO: Lorem ipsum dolor sit amet, consectetur adipiscing elit.");
+        }
+
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
+        public void IgnorePrefixesTests_DoesNotWrapLineInsideComment()
+        {
+            var input =
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit." + Environment.NewLine +
+                "TODO: Lorem ipsum dolor sit amet, consectetur adipiscing elit." + Environment.NewLine +
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+
+            // Expect all lines to be wrapped except for the one starting with "TODO".
+            var expected =
+                "Lorem ipsum dolor sit amet," + Environment.NewLine +
+                "consectetur adipiscing elit." + Environment.NewLine +
+                "TODO: Lorem ipsum dolor sit amet, consectetur adipiscing elit." + Environment.NewLine +
+                "Lorem ipsum dolor sit amet," + Environment.NewLine +
+                "consectetur adipiscing elit.";
+
+            Settings.Default.Formatting_CommentWrapColumn = 30;
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected);
+        }
+
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
+        public void IgnorePrefixesTests_DoesNotCombineSubsequentLines()
+        {
+            var input =
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit." + Environment.NewLine +
+                "TODO: Lorem ipsum dolor sit amet, consectetur adipiscing elit." + Environment.NewLine +
+                "TODO: Lorem ipsum dolor sit amet, consectetur adipiscing elit." + Environment.NewLine +
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+
+            // Expect every "ignored" line to stay on it's own.
+            var expected =
+                "Lorem ipsum dolor sit amet," + Environment.NewLine +
+                "consectetur adipiscing elit." + Environment.NewLine +
+                "TODO: Lorem ipsum dolor sit amet, consectetur adipiscing elit." + Environment.NewLine +
+                "TODO: Lorem ipsum dolor sit amet, consectetur adipiscing elit." + Environment.NewLine +
+                "Lorem ipsum dolor sit amet," + Environment.NewLine +
+                "consectetur adipiscing elit.";
+
+            Settings.Default.Formatting_CommentWrapColumn = 30;
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected);
+        }
+    }
+}

--- a/CodeMaid/CodeMaid.csproj
+++ b/CodeMaid/CodeMaid.csproj
@@ -189,6 +189,8 @@
     <Compile Include="Logic\Reorganizing\GenerateRegionLogic.cs" />
     <Compile Include="Logic\Reorganizing\RegionComparerByName.cs" />
     <Compile Include="Model\CodeItems\IInterfaceItem.cs" />
+    <Compile Include="Model\Comments\CommentOptions.cs" />
+    <Compile Include="Model\Comments\FormatterOptions.cs" />
     <Compile Include="Model\Comments\CommentLine.cs" />
     <Compile Include="Model\Comments\CommentLineXml.cs" />
     <Compile Include="Model\Comments\ICommentLine.cs" />

--- a/CodeMaid/Logic/Formatting/CommentFormatLogic.cs
+++ b/CodeMaid/Logic/Formatting/CommentFormatLogic.cs
@@ -2,6 +2,7 @@
 using SteveCadwallader.CodeMaid.Helpers;
 using SteveCadwallader.CodeMaid.Model.Comments;
 using SteveCadwallader.CodeMaid.Properties;
+using System.Linq;
 
 namespace SteveCadwallader.CodeMaid.Logic.Formatting
 {
@@ -57,13 +58,22 @@ namespace SteveCadwallader.CodeMaid.Logic.Formatting
         public bool FormatComments(TextDocument textDocument, EditPoint start, EditPoint end)
         {
             bool foundComments = false;
-            int tabSize = CodeCommentHelper.GetTabSize(_package, textDocument);
+
+            var options = new FormatterOptions
+            {
+                TabSize = CodeCommentHelper.GetTabSize(_package, textDocument),
+                IgnoreTokens = CodeCommentHelper
+                    .GetTaskListTokens(_package)
+                    .Concat(Settings.Default.Formatting_IgnoreLinesStartingWith.Cast<string>())
+                    .ToArray()
+            };
 
             while (start.Line <= end.Line)
             {
                 if (CodeCommentHelper.IsCommentLine(start))
                 {
-                    var comment = new CodeComment(start, tabSize);
+                    var comment = new CodeComment(start, options);
+
                     if (comment.IsValid)
                     {
                         comment.Format();
@@ -89,10 +99,10 @@ namespace SteveCadwallader.CodeMaid.Logic.Formatting
         }
 
         /// <summary>
-        /// Gets an instance of the <see cref="CommentFormatLogic" /> class.
+        /// Gets an instance of the <see cref="CommentFormatLogic"/> class.
         /// </summary>
         /// <param name="package">The hosting package.</param>
-        /// <returns>An instance of the <see cref="CommentFormatLogic" /> class.</returns>
+        /// <returns>An instance of the <see cref="CommentFormatLogic"/> class.</returns>
         internal static CommentFormatLogic GetInstance(CodeMaidPackage package)
         {
             return _instance ?? (_instance = new CommentFormatLogic(package));

--- a/CodeMaid/Model/Comments/CommentMatch.cs
+++ b/CodeMaid/Model/Comments/CommentMatch.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -8,7 +9,7 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
     {
         #region Constructors
 
-        public CodeCommentMatch(Match match)
+        public CodeCommentMatch(Match match, FormatterOptions formatterOptions)
         {
             if (!match.Success)
             {
@@ -16,12 +17,23 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
                 return;
             }
 
-            Indent = match.Groups["indent"].Success ? match.Groups["indent"].Value.Length : 0;
-            ListPrefix = match.Groups["listprefix"].Success ? match.Groups["listprefix"].Value : null;
-            Words = match.Groups["words"].Success ? match.Groups["words"].Captures.OfType<Capture>().Select(c => c.Value).ToList() : null;
+            if (formatterOptions.IgnoreTokens.Any(p => match.Value.StartsWith(p)))
+            {
+                Words = new List<string> { match.Groups["line"].Value };
+                IsLiteral = true;
+                IsEmpty = false;
+                IsList = false;
+            }
+            else
+            {
+                Indent = match.Groups["indent"].Success ? match.Groups["indent"].Value.Length : 0;
+                ListPrefix = match.Groups["listprefix"].Success ? match.Groups["listprefix"].Value : null;
+                Words = match.Groups["words"].Success ? match.Groups["words"].Captures.OfType<Capture>().Select(c => c.Value).ToList() : null;
 
-            IsEmpty = string.IsNullOrWhiteSpace(match.Value) || Words == null || Words.Count < 1;
-            IsList = !string.IsNullOrWhiteSpace(ListPrefix);
+                IsLiteral = false;
+                IsEmpty = string.IsNullOrWhiteSpace(match.Value) || Words == null || Words.Count < 1;
+                IsList = !string.IsNullOrWhiteSpace(ListPrefix);
+            }
 
             // In the case of a list prefix but no content (e.g. hyphen line) convert to regular content.
             if (IsEmpty && IsList)
@@ -42,6 +54,8 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
         public bool IsEmpty { get; private set; }
 
         public bool IsList { get; private set; }
+
+        public bool IsLiteral { get; private set; }
 
         public int Length
         {
@@ -79,6 +93,9 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
                 return false;
 
             if (IsList && other.Indent < 1)
+                return false;
+
+            if (IsLiteral || other.IsLiteral)
                 return false;
 
             foreach (var word in other.Words)

--- a/CodeMaid/Model/Comments/CommentOptions.cs
+++ b/CodeMaid/Model/Comments/CommentOptions.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.RegularExpressions;
+
+namespace SteveCadwallader.CodeMaid.Model.Comments
+{
+    /// <summary>
+    /// Comment specific options for the formatter.
+    /// </summary>
+    internal class CommentOptions
+    {
+        public string Prefix { get; internal set; }
+
+        public Regex Regex { get; internal set; }
+    }
+}

--- a/CodeMaid/Model/Comments/FormatterOptions.cs
+++ b/CodeMaid/Model/Comments/FormatterOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace SteveCadwallader.CodeMaid.Model.Comments
+{
+    /// <summary>
+    /// Document wide options for the comment formatter.
+    /// </summary>
+    internal class FormatterOptions
+    {
+        public int TabSize { get; internal set; }
+
+        /// <summary>
+        /// The list of comment prefix tokens to ignore while formatting the comment.
+        /// </summary>
+        public string[] IgnoreTokens { get; internal set; }
+    }
+}

--- a/CodeMaid/Properties/Settings.Designer.cs
+++ b/CodeMaid/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SteveCadwallader.CodeMaid.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.6.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -2205,6 +2205,21 @@ namespace SteveCadwallader.CodeMaid.Properties {
             }
             set {
                 this["Feature_SwitchFile"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsi=\"http://www.w3." +
+            "org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <s" +
+            "tring>ReSharper disable </string>\r\n  <string>ReSharper enable </string>\r\n</Array" +
+            "OfString>")]
+        public global::System.Collections.Specialized.StringCollection Formatting_IgnoreLinesStartingWith {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["Formatting_IgnoreLinesStartingWith"]));
+            }
+            set {
+                this["Formatting_IgnoreLinesStartingWith"] = value;
             }
         }
     }

--- a/CodeMaid/Properties/Settings.settings
+++ b/CodeMaid/Properties/Settings.settings
@@ -548,5 +548,12 @@
     <Setting Name="Feature_SwitchFile" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="Formatting_IgnoreLinesStartingWith" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
+  &lt;string&gt;ReSharper disable &lt;/string&gt;
+  &lt;string&gt;ReSharper enable &lt;/string&gt;
+&lt;/ArrayOfString&gt;</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/CodeMaid/app.config
+++ b/CodeMaid/app.config
@@ -601,6 +601,15 @@
       <setting name="Feature_SwitchFile" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="Formatting_IgnoreLinesStartingWith" serializeAs="Xml">
+        <value>
+          <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <string>ReSharper disable </string>
+            <string>ReSharper enable </string>
+          </ArrayOfString>
+        </value>
+      </setting>
     </SteveCadwallader.CodeMaid.Properties.Settings>
   </userSettings>
   <startup>


### PR DESCRIPTION
Fixes #347, #350.

Ignore (ie output literally) any comment line starting with certain prefixes while formatting. Updated the comment regex, matching, and formatter. To prevent adding even more arguments to the function calls, two options classes have been added which are now used as arguments instead.

Lines starting with any of the tokens defined in the options for the Task List Window will be ignored. The tokens must be followed by a semicolon and a space to qualify, eg `TODO: Lorem ipsum`. Matching is case sensitive.

In addition, there is a new entry in the settings file to defining other tokens to ignore. For the moment, this only contains `ReSharper disable` and  `ReSharper enable`. Once again, this is case sensitive.

Added a few unit tests to cover some obvious cases.