### PR TITLE
Do not leave trailing white space when formatting comments

### DIFF
--- a/CodeMaid.UnitTests/Formatting/XmlFormattingTests.cs
+++ b/CodeMaid.UnitTests/Formatting/XmlFormattingTests.cs
@@ -45,6 +45,53 @@ namespace SteveCadwallader.CodeMaid.UnitTests.Formatting
 
         [TestMethod]
         [TestCategory("Formatting UnitTests")]
+        public void XmlFormattingTests_AddSpaceToTagContentWithSelfClosingTag()
+        {
+            var input = "<summary><see/></summary>";
+            var expected = "<summary> <see/> </summary>";
+
+            Settings.Default.Formatting_CommentXmlSplitSummaryTagToMultipleLines = false;
+            Settings.Default.Formatting_CommentXmlSpaceTags = true;
+
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected);
+        }
+
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
+        public void XmlFormattingTests_AddSpaceToTagContentWithSelfClosingTagMultiline()
+        {
+            var input = "<summary><see/></summary>";
+            var expected =
+                "<summary>" + Environment.NewLine +
+                "<see/>" + Environment.NewLine +
+                "</summary>";
+
+            Settings.Default.Formatting_CommentXmlSplitSummaryTagToMultipleLines = true;
+            Settings.Default.Formatting_CommentXmlSpaceTags = true;
+
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected);
+        }
+
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
+        public void XmlFormattingTests_AddSpaceToTagContentShouldLeaveNoTrailingWhitespace()
+        {
+            var input = "<summary>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</summary>";
+            var expected =
+                "<summary>" + Environment.NewLine +
+                "Lorem ipsum dolor sit amet," + Environment.NewLine +
+                "consectetur adipiscing elit." + Environment.NewLine +
+                "</summary>";
+
+            Settings.Default.Formatting_CommentWrapColumn = 30;
+            Settings.Default.Formatting_CommentXmlSplitSummaryTagToMultipleLines = true;
+            Settings.Default.Formatting_CommentXmlSpaceTags = true;
+
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected);
+        }
+
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
         public void XmlFormattingTests_AllRootLevelTagsOnNewLine()
         {
             var input = "<summary>abc</summary><returns>abc</returns>";

--- a/CodeMaid/Model/Comments/CommentFormatter.cs
+++ b/CodeMaid/Model/Comments/CommentFormatter.cs
@@ -216,10 +216,6 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
                 {
                     NewLine();
                 }
-                else if (!_isFirstWord && Settings.Default.Formatting_CommentXmlSpaceTags)
-                {
-                    Append(CodeCommentHelper.Spacer);
-                }
 
                 // Always consider the word after the opening tag as the first word to prevent an
                 // extra space before.
@@ -305,11 +301,6 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
                     }
                 }
 
-                if (!forceBreak && Settings.Default.Formatting_CommentXmlSpaceTags)
-                {
-                    Append(CodeCommentHelper.Spacer);
-                }
-
                 if (_currentPosition == 0 || _currentPosition > _commentPrefixLength && forceBreak)
                 {
                     // This comment fitted on a single line.
@@ -366,6 +357,11 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
             // If true the tag should be alone on it's own line.
             tagOnOwnLine |= isLiteralContent;
 
+            if (!tagOnOwnLine && Settings.Default.Formatting_CommentXmlSpaceTags)
+            {
+                Append(CodeCommentHelper.Spacer);
+            }
+
             // If the literal content of an XML tag is set, output that content without formatting.
             if (isLiteralContent)
             {
@@ -412,9 +408,13 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
             if (tagOnOwnLine && !_isFirstWord)
             {
                 NewLine();
+                Indent(indentLevel);
+            }
+            else if (Settings.Default.Formatting_CommentXmlSpaceTags)
+            {
+                Append(CodeCommentHelper.Spacer);
             }
 
-            Indent(indentLevel);
             Append(line.CloseTag);
 
             return tagOnOwnLine || CommentLineXml.SingleLineElementNames.Contains(line.TagName, StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
Fixes #360.

Using the setting to add whitespace between XML tags and content would leave a trailing whitespace in cases when the containing XML tags are on their own line.