### PR TITLE
Switcher: Added .cshtml -> .cshtml.cs support

### DIFF
--- a/CodeMaid/Properties/Settings.Designer.cs
+++ b/CodeMaid/Properties/Settings.Designer.cs
@@ -1946,7 +1946,7 @@ namespace SteveCadwallader.CodeMaid.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute(".cpp .h||.xaml .xaml.cs||.xml .xsd||.ascx .ascx.cs||.aspx .aspx.cs||.master .mast" +
-            "er.cs")]
+            "er.cs||.cshtml .cshtml.cs")]
         public string Switching_RelatedFileExtensionsExpression {
             get {
                 return ((string)(this["Switching_RelatedFileExtensionsExpression"]));

--- a/CodeMaid/Properties/Settings.settings
+++ b/CodeMaid/Properties/Settings.settings
@@ -483,7 +483,7 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="Switching_RelatedFileExtensionsExpression" Type="System.String" Scope="User">
-      <Value Profile="(Default)">.cpp .h||.xaml .xaml.cs||.xml .xsd||.ascx .ascx.cs||.aspx .aspx.cs||.master .master.cs</Value>
+      <Value Profile="(Default)">.cpp .h||.xaml .xaml.cs||.xml .xsd||.ascx .ascx.cs||.aspx .aspx.cs||.master .master.cs||.cshtml .cshtml.cs</Value>
     </Setting>
     <Setting Name="ThirdParty_OtherCleaningCommandsExpression" Type="System.String" Scope="User">
       <Value Profile="(Default)" />

--- a/CodeMaid/app.config
+++ b/CodeMaid/app.config
@@ -536,7 +536,7 @@
         <value>False</value>
       </setting>
       <setting name="Switching_RelatedFileExtensionsExpression" serializeAs="String">
-        <value>.cpp .h||.xaml .xaml.cs||.xml .xsd||.ascx .ascx.cs||.aspx .aspx.cs||.master .master.cs</value>
+        <value>.cpp .h||.xaml .xaml.cs||.xml .xsd||.ascx .ascx.cs||.aspx .aspx.cs||.master .master.cs||.cshtml .cshtml.cs</value>
       </setting>
       <setting name="ThirdParty_OtherCleaningCommandsExpression" serializeAs="String">
         <value />


### PR DESCRIPTION
Added another entry in the `Settings.settings` file that allows easy switching between Razor Page views and PageModels (if present).