### PR TITLE
Feature Request: Insert blank lines before/after single-line fields, fixes #433

### DIFF
--- a/CodeMaid/Logic/Cleaning/InsertBlankLinePaddingLogic.cs
+++ b/CodeMaid/Logic/Cleaning/InsertBlankLinePaddingLogic.cs
@@ -77,7 +77,9 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
                     return Settings.Default.Cleaning_InsertBlankLinePaddingBeforeEvents;
 
                 case KindCodeItem.Field:
-                    return codeItem.IsMultiLine && Settings.Default.Cleaning_InsertBlankLinePaddingBeforeFieldsMultiLine;
+                    return codeItem.IsMultiLine
+                        ? Settings.Default.Cleaning_InsertBlankLinePaddingBeforeFieldsMultiLine
+                        : Settings.Default.Cleaning_InsertBlankLinePaddingBeforeFieldsSingleLine;
 
                 case KindCodeItem.Interface:
                     return Settings.Default.Cleaning_InsertBlankLinePaddingBeforeInterfaces;
@@ -138,7 +140,9 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
                     return Settings.Default.Cleaning_InsertBlankLinePaddingAfterEvents;
 
                 case KindCodeItem.Field:
-                    return codeItem.IsMultiLine && Settings.Default.Cleaning_InsertBlankLinePaddingAfterFieldsMultiLine;
+                    return codeItem.IsMultiLine
+                        ? Settings.Default.Cleaning_InsertBlankLinePaddingAfterFieldsMultiLine
+                        : Settings.Default.Cleaning_InsertBlankLinePaddingAfterFieldsSingleLine;
 
                 case KindCodeItem.Interface:
                     return Settings.Default.Cleaning_InsertBlankLinePaddingAfterInterfaces;

--- a/CodeMaid/Properties/Settings.Designer.cs
+++ b/CodeMaid/Properties/Settings.Designer.cs
@@ -2234,5 +2234,29 @@ namespace SteveCadwallader.CodeMaid.Properties {
                 this["Formatting_IgnoreLinesStartingWith"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool Cleaning_InsertBlankLinePaddingBeforeFieldsSingleLine {
+            get {
+                return ((bool)(this["Cleaning_InsertBlankLinePaddingBeforeFieldsSingleLine"]));
+            }
+            set {
+                this["Cleaning_InsertBlankLinePaddingBeforeFieldsSingleLine"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool Cleaning_InsertBlankLinePaddingAfterFieldsSingleLine {
+            get {
+                return ((bool)(this["Cleaning_InsertBlankLinePaddingAfterFieldsSingleLine"]));
+            }
+            set {
+                this["Cleaning_InsertBlankLinePaddingAfterFieldsSingleLine"] = value;
+            }
+        }
     }
 }

--- a/CodeMaid/Properties/Settings.settings
+++ b/CodeMaid/Properties/Settings.settings
@@ -558,5 +558,11 @@
   &lt;string&gt;ReSharper enable &lt;/string&gt;
 &lt;/ArrayOfString&gt;</Value>
     </Setting>
+    <Setting Name="Cleaning_InsertBlankLinePaddingBeforeFieldsSingleLine" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="Cleaning_InsertBlankLinePaddingAfterFieldsSingleLine" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/CodeMaid/UI/Dialogs/Options/Cleaning/CleaningInsertDataTemplate.xaml
+++ b/CodeMaid/UI/Dialogs/Options/Cleaning/CleaningInsertDataTemplate.xaml
@@ -17,6 +17,7 @@
                 <ToggleButton Content="enumerations" IsChecked="{Binding InsertBlankLinePaddingBeforeEnumerations}" />
                 <ToggleButton Content="events" IsChecked="{Binding InsertBlankLinePaddingBeforeEvents}" />
                 <ToggleButton Content="multi-line fields" IsChecked="{Binding InsertBlankLinePaddingBeforeFieldsMultiLine}" />
+                <ToggleButton Content="single-line fields" IsChecked="{Binding InsertBlankLinePaddingBeforeFieldsSingleLine}" />
                 <ToggleButton Content="interfaces" IsChecked="{Binding InsertBlankLinePaddingBeforeInterfaces}" />
                 <ToggleButton Content="methods" IsChecked="{Binding InsertBlankLinePaddingBeforeMethods}" />
                 <ToggleButton Content="multi-line properties" IsChecked="{Binding InsertBlankLinePaddingBeforePropertiesMultiLine}" />
@@ -42,6 +43,7 @@
                 <ToggleButton Content="enumerations" IsChecked="{Binding InsertBlankLinePaddingAfterEnumerations}" />
                 <ToggleButton Content="events" IsChecked="{Binding InsertBlankLinePaddingAfterEvents}" />
                 <ToggleButton Content="multi-line fields" IsChecked="{Binding InsertBlankLinePaddingAfterFieldsMultiLine}" />
+                <ToggleButton Content="single-line fields" IsChecked="{Binding InsertBlankLinePaddingAfterFieldsSingleLine}" />
                 <ToggleButton Content="interfaces" IsChecked="{Binding InsertBlankLinePaddingAfterInterfaces}" />
                 <ToggleButton Content="methods" IsChecked="{Binding InsertBlankLinePaddingAfterMethods}" />
                 <ToggleButton Content="multi-line properties" IsChecked="{Binding InsertBlankLinePaddingAfterPropertiesMultiLine}" />

--- a/CodeMaid/UI/Dialogs/Options/Cleaning/CleaningInsertViewModel.cs
+++ b/CodeMaid/UI/Dialogs/Options/Cleaning/CleaningInsertViewModel.cs
@@ -25,6 +25,7 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.Cleaning
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingAfterEnumerations, x => InsertBlankLinePaddingAfterEnumerations),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingAfterEvents, x => InsertBlankLinePaddingAfterEvents),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingAfterFieldsMultiLine, x => InsertBlankLinePaddingAfterFieldsMultiLine),
+                new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingAfterFieldsSingleLine, x => InsertBlankLinePaddingAfterFieldsSingleLine),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingAfterInterfaces, x => InsertBlankLinePaddingAfterInterfaces),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingAfterMethods, x => InsertBlankLinePaddingAfterMethods),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingAfterNamespaces, x => InsertBlankLinePaddingAfterNamespaces),
@@ -40,6 +41,7 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.Cleaning
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingBeforeEnumerations, x => InsertBlankLinePaddingBeforeEnumerations),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingBeforeEvents, x => InsertBlankLinePaddingBeforeEvents),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingBeforeFieldsMultiLine, x => InsertBlankLinePaddingBeforeFieldsMultiLine),
+                new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingBeforeFieldsSingleLine, x => InsertBlankLinePaddingBeforeFieldsSingleLine),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingBeforeInterfaces, x => InsertBlankLinePaddingBeforeInterfaces),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingBeforeMethods, x => InsertBlankLinePaddingBeforeMethods),
                 new SettingToOptionMapping<bool, bool>(x => ActiveSettings.Cleaning_InsertBlankLinePaddingBeforeNamespaces, x => InsertBlankLinePaddingBeforeNamespaces),
@@ -126,6 +128,15 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.Cleaning
         /// Gets or sets the flag indicating if blank line padding should be added after multi-line fields.
         /// </summary>
         public bool InsertBlankLinePaddingAfterFieldsMultiLine
+        {
+            get { return GetPropertyValue<bool>(); }
+            set { SetPropertyValue(value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the flag indicating if blank line padding should be added after single-line fields.
+        /// </summary>
+        public bool InsertBlankLinePaddingAfterFieldsSingleLine
         {
             get { return GetPropertyValue<bool>(); }
             set { SetPropertyValue(value); }
@@ -262,6 +273,15 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options.Cleaning
         /// Gets or sets the flag indicating if blank line padding should be added before multi-line fields.
         /// </summary>
         public bool InsertBlankLinePaddingBeforeFieldsMultiLine
+        {
+            get { return GetPropertyValue<bool>(); }
+            set { SetPropertyValue(value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the flag indicating if blank line padding should be added before single-line fields.
+        /// </summary>
+        public bool InsertBlankLinePaddingBeforeFieldsSingleLine
         {
             get { return GetPropertyValue<bool>(); }
             set { SetPropertyValue(value); }

--- a/CodeMaid/app.config
+++ b/CodeMaid/app.config
@@ -613,6 +613,14 @@
           </ArrayOfString>
         </value>
       </setting>
+      <setting name="Cleaning_InsertBlankLinePaddingBeforeFieldsSingleLine"
+        serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Cleaning_InsertBlankLinePaddingAfterFieldsSingleLine"
+        serializeAs="String">
+        <value>False</value>
+      </setting>
     </SteveCadwallader.CodeMaid.Properties.Settings>
   </userSettings>
   <startup>


### PR DESCRIPTION
Fix for #433 

I added the ability to insert blank lines before and after single line fields. The changes mirrors the same logic that was followed for adding lines before and after single line properties. These new settings have been added as user settings and are defaulted to false. They're available in the options UI on the insert page. I placed them next to the "multi-line fields" options that already existed.