### PR TITLE
Remove blank newline in self-closing doc comment

### DIFF
--- a/CodeMaid/Model/Comments/CommentFormatter.cs
+++ b/CodeMaid/Model/Comments/CommentFormatter.cs
@@ -337,7 +337,10 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
             {
                 if (tagOnOwnLine)
                 {
-                    NewLine();
+                    if (!line.IsLastNode)
+                    {
+                        NewLine();
+                    }
                     return false;
                 }
                 return true;

--- a/CodeMaid/Model/Comments/CommentLineXml.cs
+++ b/CodeMaid/Model/Comments/CommentLineXml.cs
@@ -41,6 +41,8 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
             _innerText = new StringBuilder();
             ParseChildNodes(xml);
             CloseInnerText();
+
+            IsLastNode = xml.Parent?.NextNode == null;
         }
 
         #endregion Constructors
@@ -56,6 +58,8 @@ namespace SteveCadwallader.CodeMaid.Model.Comments
         public string OpenTag { get; set; }
 
         public string TagName { get; private set; }
+
+        public bool IsLastNode { get; private set; }
 
         #endregion Properties
 


### PR DESCRIPTION
## Issue

Ending a doc comment with a self-closing XML tag will cause CodeMaid to add a trailing comment line.

### Example

CodeMaid will format a document to look like the following
```csharp
/// <seealso cref="IFormattable.ToString(String, IFormatProvider)"/>
///
public static string GetUIString(IFormattable value, string format = null)
{
    return value?.ToString(format, CurrentUICulture);
}
```

## Resolution

Check whether a self-closing tag was the end of the XML comment block, and skip adding a new line if it is. Fixes #599.

### Example

CodeMaid will format a document to look like the following
```csharp
/// <seealso cref="IFormattable.ToString(String, IFormatProvider)"/>
public static string GetUIString(IFormattable value, string format = null)
{
    return value?.ToString(format, CurrentUICulture);
}
```

## Tests

I could not set up unit tests in my environment, so I have no guarantees that this works outside of the test runs I did on my own projects.

