### PR TITLE
Fix magically added slashes

### DIFF
--- a/CodeMaid.UnitTests/Formatting/FormatWithPrefixTests.cs
+++ b/CodeMaid.UnitTests/Formatting/FormatWithPrefixTests.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SteveCadwallader.CodeMaid.Properties;
-using System;
 
 namespace SteveCadwallader.CodeMaid.UnitTests.Formatting
 {
@@ -30,8 +30,35 @@ namespace SteveCadwallader.CodeMaid.UnitTests.Formatting
         [TestCategory("Formatting UnitTests")]
         public void SimpleFormatWithPrefixTests_TrimsTrailingSpace()
         {
-            var input = "//   ";
-            var expected = "//";
+            var input = "// Trailing space  ";
+            var expected = "// Trailing space";
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected, "//");
+        }
+
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
+        public void SimpleFormatWithPrefixTests_TrimsTrailingLines()
+        {
+            var input =
+                "// Comment with some trailing lines" + Environment.NewLine +
+                "//" + Environment.NewLine +
+                "//";
+            var expected =
+                "// Comment with some trailing lines";
+            CommentFormatHelper.AssertEqualAfterFormat(input, expected, "//");
+        }
+
+        [TestMethod]
+        [TestCategory("Formatting UnitTests")]
+        public void SimpleFormatWithPrefixTests_TrimsLeadingLines()
+        {
+            var input =
+                "//" + Environment.NewLine +
+                "//" + Environment.NewLine +
+                "// Comment with some leading lines";
+            var expected =
+                "// Comment with some leading lines";
+
             CommentFormatHelper.AssertEqualAfterFormat(input, expected, "//");
         }
 

--- a/CodeMaid/.editorconfig
+++ b/CodeMaid/.editorconfig
@@ -1,0 +1,8 @@
+; Top-most EditorConfig file
+root = true
+
+[*.{cs,vb}]
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion


### PR DESCRIPTION
Once again, I cannot seem to fix an issue without reorganizing half the formatting code. 

Up to now, a call to `NewLine()` created a newline and immediately wrote a comment prefix (eg `///`). Then indenting was added manually from the individual line formatter. 
I've changed this to add the prefix and optional indenting when the first word is added to the output, which makes for a more logical and less error prone process. It's still messy, but slightly less so 😉 

At least this fixes #646. 