### PR TITLE
(WIP) Adds file header variable replacement feature

### DIFF
--- a/CodeMaid/CodeMaid.csproj
+++ b/CodeMaid/CodeMaid.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Integration\Commands\SpadeSearchCommand.cs" />
     <Compile Include="Integration\ISwitchableFeature.cs" />
     <Compile Include="Logic\Cleaning\FileHeaderLogic.cs" />
+    <Compile Include="Logic\Cleaning\FileHeaderVariable.cs" />
     <Compile Include="Logic\Cleaning\RemoveRegionLogic.cs" />
     <Compile Include="Logic\Formatting\CommentFormatLogic.cs" />
     <Compile Include="Logic\Reorganizing\CodeReorganizationAvailabilityLogic.cs" />

--- a/CodeMaid/Logic/Cleaning/FileHeaderLogic.cs
+++ b/CodeMaid/Logic/Cleaning/FileHeaderLogic.cs
@@ -1,7 +1,11 @@
-﻿using EnvDTE;
+using EnvDTE;
 using SteveCadwallader.CodeMaid.Helpers;
 using SteveCadwallader.CodeMaid.Properties;
 using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace SteveCadwallader.CodeMaid.Logic.Cleaning
 {
@@ -13,6 +17,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
         #region Fields
 
         private readonly CodeMaidPackage _package;
+        private readonly ConcurrentDictionary<string,Regex> _cachedTemplates;
 
         #endregion Fields
 
@@ -40,6 +45,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
         private FileHeaderLogic(CodeMaidPackage package)
         {
             _package = package;
+            _cachedTemplates = new ConcurrentDictionary<string, Regex>();
         }
 
         #endregion Constructors
@@ -52,20 +58,140 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
         /// <param name="textDocument">The text document to update.</param>
         internal void UpdateFileHeader(TextDocument textDocument)
         {
-            var settingsFileHeader = GetFileHeaderFromSettings(textDocument);
-            if (string.IsNullOrWhiteSpace(settingsFileHeader))
+            var headerTemplate = GetFileHeaderFromSettings(textDocument);
+            if (string.IsNullOrWhiteSpace(headerTemplate))
             {
                 return;
             }
 
-            var cursor = textDocument.StartPoint.CreateEditPoint();
-            var existingFileHeader = cursor.GetText(settingsFileHeader.Length);
+            // Match against the file header based on lines
+            var headerLineLength = headerTemplate
+                .Split(new string[] { Environment.NewLine }, StringSplitOptions.None)
+                .Length;
 
-            if (!existingFileHeader.StartsWith(settingsFileHeader))
+            var documentLineLength = textDocument.EndPoint.Line;
+            var cursor = textDocument.StartPoint.CreateEditPoint();
+            var existingFileHeader = cursor.GetLines(1, Math.Min(headerLineLength, documentLineLength) + 1);
+
+            var variables = GetReplacementVariables(textDocument);
+            var headerPattern = BuildHeaderMatchPattern(variables, headerTemplate);
+            var matchResult = headerPattern.Match(existingFileHeader);
+            var updatedHeader = BuildHeader(variables, headerTemplate, matchResult);
+
+            if (!existingFileHeader.StartsWith(updatedHeader))
             {
-                cursor.Insert(settingsFileHeader);
+                // delete the existing header that matches our pattern
+                if (matchResult.Success)
+                {
+                    var endOfHeader = textDocument.StartPoint.CreateEditPoint();
+                    endOfHeader.LineDown(headerLineLength);
+                    cursor.Delete(endOfHeader);
+                }
+
+                cursor.Insert(updatedHeader);
                 cursor.Insert(Environment.NewLine);
             }
+        }
+
+        /// <summary>
+        /// Builds a regular expression that matches the file header based on the provided template
+        /// </summary>
+        /// <param name="variables">Variables that can have values substituted in the header</param>
+        /// <param name="headerTemplate">Template possibly containing variables</param>
+        /// <returns></returns>
+        private Regex BuildHeaderMatchPattern(FileHeaderVariable[] variables, string headerTemplate)
+        {
+            if (_cachedTemplates.TryGetValue(headerTemplate, out var cachedRegex))
+            {
+                return cachedRegex;
+            }
+
+            var resultBuilder = new StringBuilder();
+            resultBuilder.Append("^");
+            resultBuilder.Append(Regex.Escape(headerTemplate));
+
+            // Tolerate mixed line endings
+            resultBuilder.Replace(@"\r", "");
+            resultBuilder.Replace(@"\n", @"\r?\n");
+
+            foreach (var variable in variables)
+            {
+                // Because the settingsFileHeader was regex escaped above,
+                // we need to escape the variable name before replacing it with a regex value.
+                var escapedName = Regex.Escape("$" + variable.Name + "$");
+
+                // Wrap the pattern in a capture so its value can be retrieved by variable name later
+                var namedCapture = "(?<" + variable.Name + ">" + variable.MatchPattern + ")";
+                resultBuilder.Replace(escapedName, namedCapture);
+            }
+
+            resultBuilder.Append("$");
+
+            var compiledRegex = new Regex(resultBuilder.ToString(), RegexOptions.Compiled);
+            _cachedTemplates[headerTemplate] = compiledRegex;
+            return compiledRegex;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="variables"></param>
+        /// <param name="headerTemplate"></param>
+        /// <param name="matchResult"></param>
+        /// <returns></returns>
+        private string BuildHeader(FileHeaderVariable[] variables, string headerTemplate, Match matchResult)
+        {
+            var resultBuilder = new StringBuilder();
+            resultBuilder.Append(headerTemplate);
+
+            foreach (var variable in variables)
+            {
+                // matchResult[...].Groups.Value will be an empty string if there are no matches
+                // for the group or the group doesnt exist. Only one value will be used, so if
+                // the variable appears multiple times in the file header only the last value
+                // is actually taken
+                var existingValue = matchResult.Groups[variable.Name].Value;
+
+                var replacement = variable.GetReplacementValue(existingValue);
+                resultBuilder.Replace("$" + variable.Name + "$", replacement);
+            }
+
+            return resultBuilder.ToString();
+        }
+
+
+        /// <summary>
+        /// Gets the variables for replacement in file headers.
+        /// </summary>
+        /// <param name="textDocument">The text document to get variables from.</param>
+        /// <returns>An array of FileHeaderVariables</returns>
+        private FileHeaderVariable[] GetReplacementVariables(TextDocument textDocument)
+        {
+            var fileNamePattern = @"[^\\/""\t\r\n<>|:*?]{0,255}";
+
+            var currentYear = DateTime.Now.Year.ToString("0000");
+
+            var isModified = textDocument.Parent?.ProjectItem?.IsDirty ?? false;
+
+            var solutionName = string.Empty;
+            if (_package.IDE.Solution != null)
+            {
+                solutionName = Path.GetFileNameWithoutExtension(_package.IDE.Solution.FileName);
+            }
+
+            var projectName = textDocument.Parent?.ProjectItem?.ProjectItems?.ContainingProject?.Name ?? string.Empty;
+
+            var fileName = textDocument?.Parent?.Name ?? string.Empty;
+
+            return new FileHeaderVariable[]
+            {
+                new FileHeaderVariable("MODIFIEDYEAR", @"\d{4}", previousValue => (isModified || string.IsNullOrEmpty(previousValue)) ? currentYear : previousValue),
+                new FileHeaderVariable("CREATEDYEAR", @"\d{4}", previousValue => string.IsNullOrEmpty(previousValue) ? currentYear : previousValue),
+                new FileHeaderVariable("CURRENTYEAR", @"\d{4}", _ =>  currentYear),
+                new FileHeaderVariable("FILENAME", fileNamePattern, _ => fileName),
+                new FileHeaderVariable("PROJECT", fileNamePattern, _ => projectName),
+                new FileHeaderVariable("SOLUTION", fileNamePattern, _ => solutionName),
+            };
         }
 
         /// <summary>

--- a/CodeMaid/Logic/Cleaning/FileHeaderVariable.cs
+++ b/CodeMaid/Logic/Cleaning/FileHeaderVariable.cs
@@ -1,0 +1,43 @@
+using EnvDTE;
+using System;
+
+namespace SteveCadwallader.CodeMaid.Logic.Cleaning
+{
+    /// <summary>
+    /// Represents a dynamic value that can be substituted into a file header by the file header update logic.
+    /// </summary>
+    public class FileHeaderVariable
+    {
+        private readonly Func<string,string> _getReplacementValue;
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="FileHeaderVariable"/> class.
+        /// </summary>
+        /// <param name="name">The string value that represents this variable in the file header settings</param>
+        /// <param name="matchPattern">A pattern that matches this variable's value in a file header.</param>
+        /// <param name="getReplacementValue">A function to generate a replacement value.</param>
+        public FileHeaderVariable(string name, string matchPattern, Func<string,string> getReplacementValue)
+        {
+            Name = name;
+            MatchPattern = matchPattern;
+            _getReplacementValue = getReplacementValue;
+        }
+
+        /// <summary>
+        /// Gets the string value that represents this variable in the File Header Settings.
+        /// </summary>
+        public string Name { get; }
+        
+        /// <summary>
+        /// A regular expression that matches this variable in the document text's file header.
+        /// </summary>
+        public string MatchPattern { get; }
+
+        /// <summary>
+        /// Generates a value to replace this variable with when updating the file header.
+        /// </summary>
+        /// <param name="currentValue">The current value of the variable in the file header.</param>
+        /// <returns>The value that should replace the variable</returns>
+        public string GetReplacementValue(string currentValue) => _getReplacementValue(currentValue);
+    }
+}


### PR DESCRIPTION
This is semi WIP. I've tested it myself by just debugging in VS 2017, and I plan to dog food it with my team a bit if you agree on the general functional approach. Unfortunately I haven't been able to run the integration tests in 2017 or 2019. Wasn't sure how to get past that. Just wanted to throw it up so you could see it and I could get some feedback or tips on how to run integration tests. Also wasn't sure how you'd want to update documentation or any of the instructions on the UI.

I didn't base it on the existing PR by the other author because I modeled the problem differently to solve the problems and limitations of that approach.

The approach is that variables are matched using a regex constructed from the file header, and can be updated dynamically based on the previous value. It's implemented in a way so future variables and behaviors could be added very simply. 

Adds feature where variables like $CREATEDYEAR$ and $PROJECT$ are
substituted with dynamic values in the file header. The file header is
updated if a matching header is present, even if the variable's values
have changed. Otherwise, a new header is inserted.

The goal was to preserve all original functionality with the previous
file header update logic, and make this an additive change. As such the
logic is langauge agnostic and works for any style comment syntax or any
arbitrary header with any of the substitution variables provided. It assumes (like the previous file header logic) that the file header does appear on its own lines.