### PR TITLE
Ensure imported Config File is not read-only

### DIFF
--- a/CodeMaid/UI/Dialogs/Options/OptionsViewModel.cs
+++ b/CodeMaid/UI/Dialogs/Options/OptionsViewModel.cs
@@ -283,6 +283,7 @@ namespace SteveCadwallader.CodeMaid.UI.Dialogs.Options
                 try
                 {
                     File.Copy(dialog.FileName, ActiveSettingsPath, true);
+                    File.SetAttributes(ActiveSettingsPath, File.GetAttributes(ActiveSettingsPath) & ~FileAttributes.ReadOnly);
 
                     RefreshPackageSettings();
 


### PR DESCRIPTION
Had a little bug, where the config file was copied from a global storage and setted read-only.
First time it works, but if i tryed to re-import the file i got an exception because the target file is now read-only.
This fix should ensure that the imported file is always not read-only and keeps all other file attributes from the original config.