### PR TITLE
Remove and sort namespaces in .XAML files. Fixes `#551`

### DIFF
--- a/CodeMaid/Logic/Cleaning/CodeCleanupManager.cs
+++ b/CodeMaid/Logic/Cleaning/CodeCleanupManager.cs
@@ -478,7 +478,10 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
             var textDocument = document.GetTextDocument();
 
             RunExternalFormatting(textDocument);
-
+            if (!document.IsExternal())
+            {
+                _usingStatementCleanupLogic.RemoveAndSortUsingStatements(textDocument);
+            }
             // Perform file header cleanup.
             _fileHeaderLogic.UpdateFileHeader(textDocument);
 


### PR DESCRIPTION
Call the RemoveAndSortUsingStatements() also on XAML files. I've tested the changes also with the other Markup filetypes (XML and HTML) and also with the CodeMaid setting "Cleaning - Visual Studio" "Using statements to re-insert when removed" and no problems occurred.