### PR TITLE
Fix Bug: RemoveAndSortUsings

### DIFF
--- a/CodeMaid/Logic/Cleaning/UsingStatementCleanupLogic.cs
+++ b/CodeMaid/Logic/Cleaning/UsingStatementCleanupLogic.cs
@@ -1,5 +1,4 @@
 using EnvDTE;
-using Microsoft.VisualStudio.Shell;
 using SteveCadwallader.CodeMaid.Helpers;
 using SteveCadwallader.CodeMaid.Properties;
 using System;
@@ -92,18 +91,20 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
                  .Where(usingStatement => TextDocumentHelper.FirstOrDefaultMatch(textDocument, string.Format(patternFormat, usingStatement)) == null)
                  .ToList();
 
-            ThreadHelper.ThrowIfNotOnUIThread();
-            var point = textDocument.StartPoint.CreateEditPoint();
-
-            foreach (string usingStatement in usingStatementsToReinsert)
+            if (usingStatementsToReinsert.Count > 0)
             {
-                point.StartOfLine();
-                point.Insert(usingStatement);
-                point.Insert(Environment.NewLine);
-            }
+                var point = textDocument.StartPoint.CreateEditPoint();
 
-            // Now sort without removing to ensure correct ordering.
-            _commandHelper.ExecuteCommand(textDocument, "Edit.SortUsings");
+                foreach (string usingStatement in usingStatementsToReinsert)
+                {
+                    point.StartOfLine();
+                    point.Insert(usingStatement);
+                    point.Insert(Environment.NewLine);
+                }
+
+                // Now sort without removing to ensure correct ordering.
+                _commandHelper.ExecuteCommand(textDocument, "Edit.SortUsings");
+            }
         }
 
         #endregion Methods


### PR DESCRIPTION
Prevent duplicate using statements from being re-added.

This is somewhat related to #659, but I didn't see a bug describing this exact situation.

I'm including repro steps. Let me know if you would like me to move that out to a separate issue.

Visual Studio 2019 express. Windows 10.

1. Ensure CodeMaid Options match included image.
![image](https://user-images.githubusercontent.com/64854403/81109851-fce1f100-8ed7-11ea-8667-917ddf01cd05.png)
2. Cleanup Active Document.

Expected: Includes all referenced usings, and at most one instance of each using in CodeMaid options.
Actual: Reorders usings and adds duplicates.

[RemoveAndSortUsings Bug Example.zip](https://github.com/codecadwallader/codemaid/files/4583329/RemoveAndSortUsings.Bug.Example.zip)




