### PR TITLE
Adjust the size and location of the outline load progress bar when saving files

### DIFF
--- a/CodeMaid/UI/ToolWindows/Spade/RadialProgressBar.xaml
+++ b/CodeMaid/UI/ToolWindows/Spade/RadialProgressBar.xaml
@@ -9,7 +9,7 @@
 
              mc:Ignorable="d"
              x:Name="MainVindow"
-             d:DesignHeight="100" d:DesignWidth="100">
+             d:DesignHeight="10" d:DesignWidth="10">
 
     <UserControl.Resources>
         <ResourceDictionary>
@@ -21,8 +21,8 @@
 
             <local:CenterConverter x:Key="CenterConverter" />
             <Style x:Key ="rectangle" TargetType="{x:Type Rectangle}">
-                <Setter Property="Width" Value="4" />
-                <Setter Property="Height" Value="15" />
+                <Setter Property="Width" Value="3" />
+                <Setter Property="Height" Value="1" />
                 <Setter Property="Fill" Value="{StaticResource FCodeMaidGreen}" />
                 <Setter Property="Canvas.Left" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type Canvas}},Path=ActualWidth,Converter={StaticResource CenterConverter}}" />
                 <Setter Property="Canvas.Top" Value="0" />

--- a/CodeMaid/UI/ToolWindows/Spade/SpadeView.xaml
+++ b/CodeMaid/UI/ToolWindows/Spade/SpadeView.xaml
@@ -168,34 +168,37 @@
             </TreeView.ItemTemplateSelector>
         </TreeView>
 
-        <Border Background="{DynamicResource FOverlay}"
-                Visibility="{Binding IsRefreshing, Converter={x:Static cnv:BooleanToVisibilityConverter.Default}}" />
+        <Border Visibility="{Binding IsRefreshing, Converter={x:Static cnv:BooleanToVisibilityConverter.Default}}" >
+            <Border.Background>
+                <SolidColorBrush Opacity="0" Color="#00000000"/>
+            </Border.Background>
+        </Border>
 
-        <ContentControl Content="{Binding}" Focusable="False" VerticalAlignment="Center">
+        <ContentControl Content="{Binding}" Focusable="False" VerticalAlignment="Top">
             <ContentControl.ContentTemplate>
                 <DataTemplate>
                     <Border x:Name="outerBorder"
-                            Background="{DynamicResource FWindow}"
+                            Background="#00000000"
                             BorderBrush="{StaticResource FCodeMaidGreen}"
                             BorderThickness="0" Margin="1,0" Padding="0,5" Visibility="Collapsed">
-                        <StackPanel HorizontalAlignment="Center">
-                            <local:RadialProgressBar Width="80" Height="80" Margin="5" />
-                            <TextBlock x:Name="stateLabel" FontSize="14" FontStyle="Italic"
+                        <StackPanel HorizontalAlignment="Right">
+                            <local:RadialProgressBar Width="10" Height="10" Margin="5" />
+                            <!--<TextBlock x:Name="stateLabel" FontSize="14" FontStyle="Italic"
                                     Foreground="{StaticResource FCodeMaidGray}" />
                             <TextBlock FontSize="16"
                                        FontWeight="SemiBold"
                                        Foreground="{StaticResource FCodeMaidGreen}"
-                                       Text="{Binding Document.Name}" />
+                                       Text="{Binding Document.Name}" />-->
                         </StackPanel>
                     </Border>
                     <DataTemplate.Triggers>
                         <DataTrigger Binding="{Binding IsLoading}" Value="True">
                             <Setter TargetName="outerBorder" Property="Visibility" Value="Visible" />
-                            <Setter TargetName="stateLabel" Property="Text" Value="{x:Static p:Resources.Loading}" />
+                            <!--<Setter TargetName="stateLabel" Property="Text" Value="{x:Static p:Resources.Loading}" />-->
                         </DataTrigger>
                         <DataTrigger Binding="{Binding IsRefreshing}" Value="True">
                             <Setter TargetName="outerBorder" Property="Visibility" Value="Visible" />
-                            <Setter TargetName="stateLabel" Property="Text" Value="{x:Static p:Resources.Refreshing}" />
+                            <!--<Setter TargetName="stateLabel" Property="Text" Value="{x:Static p:Resources.Refreshing}" />-->
                         </DataTrigger>
                     </DataTemplate.Triggers>
                 </DataTemplate>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21293084/84563493-8f569980-ad8e-11ea-963c-875ed4be7428.png)

Adjust the size and location of the outline load progress bar when saving files
调整保存文件时大纲加载进度条的大小和位置

The previously centered load icon is too large. Neither viusal assist x and resharper current output outline and file structure not  shows the progress of the loading process. So I moved to the top right and resized.
原先居中的加载图标过大。番茄助手和resharper目前的outline 和file Structure都没有加载过程的进度显示。所以我移到了右上角，并调整了大小。

Because I don't know whether the English translation is correct or not, and whether it is a misunderstanding, I wrote the corresponding Chinese, hoping to be helpful
由于我不知道英文翻译的对不对，是否照成误解，所以写上了相应的中文，希望能够有所帮助

