### PR TITLE
Replace usage of FindPattern/ReplacePattern with IFindService

### DIFF
--- a/CodeMaid.IntegrationTests/CodeMaid.IntegrationTests.csproj
+++ b/CodeMaid.IntegrationTests/CodeMaid.IntegrationTests.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.Interop, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VSSDK.TestHostFramework, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VSSDK.TestHostFramework" />
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/CodeMaid.IntegrationTests/CodeMaid.IntegrationTests.csproj
+++ b/CodeMaid.IntegrationTests/CodeMaid.IntegrationTests.csproj
@@ -42,8 +42,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.Interop, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VSSDK.TestHostFramework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VSSDK.TestHostFramework, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -855,7 +856,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>15.0.1</Version>
+      <Version>17.0.0-previews-2-31512-422</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\CodeMaid.IntegrationTestsShared\CodeMaid.IntegrationTestsShared.projitems" Label="Shared" />

--- a/CodeMaid.VS2022/CodeMaid.VS2022.csproj
+++ b/CodeMaid.VS2022/CodeMaid.VS2022.csproj
@@ -730,10 +730,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.1</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
-      <Version>1.5.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>

--- a/CodeMaid/CodeMaid.csproj
+++ b/CodeMaid/CodeMaid.csproj
@@ -340,7 +340,7 @@
       <Version>1.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>15.0.1</Version>
+      <Version>17.0.0-previews-2-31512-422</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.0.3177-preview3</Version>

--- a/CodeMaid/CodeMaid.csproj
+++ b/CodeMaid/CodeMaid.csproj
@@ -348,10 +348,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.1</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
-      <Version>1.5.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>

--- a/CodeMaidShared/CodeMaidPackage.cs
+++ b/CodeMaidShared/CodeMaidPackage.cs
@@ -76,7 +76,9 @@ namespace SteveCadwallader.CodeMaid
         /// </summary>
         private ThemeManager _themeManager;
 
-
+        /// <summary>
+        /// Fully initialized package instance.
+        /// </summary>
         internal static CodeMaidPackage Instance;
 
         /// <summary>

--- a/CodeMaidShared/CodeMaidPackage.cs
+++ b/CodeMaidShared/CodeMaidPackage.cs
@@ -76,6 +76,9 @@ namespace SteveCadwallader.CodeMaid
         /// </summary>
         private ThemeManager _themeManager;
 
+
+        internal static CodeMaidPackage Instance;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CodeMaidPackage"/> class.
         /// </summary>
@@ -200,6 +203,8 @@ namespace SteveCadwallader.CodeMaid
 
             await RegisterCommandsAsync();
             await RegisterEventListenersAsync();
+
+            Instance = this;
         }
 
         /// <summary>

--- a/CodeMaidShared/Helpers/TextDocumentHelper.cs
+++ b/CodeMaidShared/Helpers/TextDocumentHelper.cs
@@ -47,12 +47,14 @@ namespace SteveCadwallader.CodeMaid.Helpers
             ThreadHelper.ThrowIfNotOnUIThread();
 
             var matches = new List<EditPoint>();
-            var textBuffer = GetTextBufferAt(textDocument.Parent.FullName, CodeMaidPackage.Instance.ComponentModel, CodeMaidPackage.Instance);
-            IFinder finder = GetFinder(patternString, textBuffer);
-            var findMatches = finder.FindAll();
-            foreach (var match in findMatches)
+            if (TryGetTextBufferAt(textDocument.Parent.FullName, out ITextBuffer textBuffer))
             {
-                matches.Add(GetEditPointForSnapshotPosition(textDocument, textBuffer.CurrentSnapshot, match.Start));
+                IFinder finder = GetFinder(patternString, textBuffer);
+                var findMatches = finder.FindAll();
+                foreach (var match in findMatches)
+                {
+                    matches.Add(GetEditPointForSnapshotPosition(textDocument, textBuffer.CurrentSnapshot, match.Start));
+                }
             }
 
             return matches;
@@ -86,12 +88,14 @@ namespace SteveCadwallader.CodeMaid.Helpers
             ThreadHelper.ThrowIfNotOnUIThread();
 
             var matches = new List<EditPoint>();
-            var textBuffer = GetTextBufferAt(textSelection.Parent.Parent.FullName, CodeMaidPackage.Instance.ComponentModel, CodeMaidPackage.Instance);
-            IFinder finder = GetFinder(patternString, textBuffer);
-            var findMatches = finder.FindAll(GetSnapshotSpanForTextSelection(textBuffer.CurrentSnapshot, textSelection));
-            foreach (var match in findMatches)
+            if (TryGetTextBufferAt(textSelection.Parent.Parent.FullName, out ITextBuffer textBuffer))
             {
-                matches.Add(GetEditPointForSnapshotPosition(textSelection.Parent, textBuffer.CurrentSnapshot, match.Start));
+                IFinder finder = GetFinder(patternString, textBuffer);
+                var findMatches = finder.FindAll(GetSnapshotSpanForTextSelection(textBuffer.CurrentSnapshot, textSelection));
+                foreach (var match in findMatches)
+                {
+                    matches.Add(GetEditPointForSnapshotPosition(textSelection.Parent, textBuffer.CurrentSnapshot, match.Start));
+                }
             }
 
             return matches;
@@ -106,11 +110,14 @@ namespace SteveCadwallader.CodeMaid.Helpers
         internal static EditPoint FirstOrDefaultMatch(TextDocument textDocument, string patternString)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            ITextBuffer textBuffer = GetTextBufferAt(textDocument.Parent.FullName, CodeMaidPackage.Instance.ComponentModel, CodeMaidPackage.Instance);
-            IFinder finder = GetFinder(patternString, textBuffer);
-            if (finder.TryFind(out Span match))
+
+            if (TryGetTextBufferAt(textDocument.Parent.FullName, out ITextBuffer textBuffer))
             {
-                return GetEditPointForSnapshotPosition(textDocument, textBuffer.CurrentSnapshot, match.Start);
+                IFinder finder = GetFinder(patternString, textBuffer);
+                if (finder.TryFind(out Span match))
+                {
+                    return GetEditPointForSnapshotPosition(textDocument, textBuffer.CurrentSnapshot, match.Start);
+                }
             }
 
             return null;
@@ -127,13 +134,16 @@ namespace SteveCadwallader.CodeMaid.Helpers
         internal static bool TryFindNextMatch(EditPoint startPoint, ref EditPoint endPoint, string patternString)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var textBuffer = GetTextBufferAt(startPoint.Parent.Parent.FullName, CodeMaidPackage.Instance.ComponentModel, CodeMaidPackage.Instance);
-            IFinder finder = GetFinder(patternString, textBuffer);
 
-            if (finder.TryFind(GetSnapshotPositionForTextPoint(textBuffer.CurrentSnapshot, startPoint), out Span match))
+            if (TryGetTextBufferAt(startPoint.Parent.Parent.FullName, out ITextBuffer textBuffer))
             {
-                endPoint = GetEditPointForSnapshotPosition(startPoint.Parent, textBuffer.CurrentSnapshot, match.End);
-                return true;
+                IFinder finder = GetFinder(patternString, textBuffer);
+
+                if (finder.TryFind(GetSnapshotPositionForTextPoint(textBuffer.CurrentSnapshot, startPoint), out Span match))
+                {
+                    endPoint = GetEditPointForSnapshotPosition(startPoint.Parent, textBuffer.CurrentSnapshot, match.End);
+                    return true;
+                }
             }
 
             return false;
@@ -149,11 +159,13 @@ namespace SteveCadwallader.CodeMaid.Helpers
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            var textBuffer = GetTextBufferAt(startPoint.Parent.Parent.FullName, CodeMaidPackage.Instance.ComponentModel, CodeMaidPackage.Instance);
-            IFinder finder = GetFinder(matchString, textBuffer);
-            if (finder.TryFind(out Span match))
+            if (TryGetTextBufferAt(startPoint.Parent.Parent.FullName, out ITextBuffer textBuffer))
             {
-                return textBuffer.CurrentSnapshot.GetText(match);
+                IFinder finder = GetFinder(matchString, textBuffer);
+                if (finder.TryFind(out Span match))
+                {
+                    return textBuffer.CurrentSnapshot.GetText(match);
+                }
             }
 
             return null;
@@ -165,6 +177,8 @@ namespace SteveCadwallader.CodeMaid.Helpers
         /// <param name="point">The point.</param>
         internal static void InsertBlankLineBeforePoint(EditPoint point)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (point.Line <= 1) return;
 
             point.LineUp(1);
@@ -184,6 +198,8 @@ namespace SteveCadwallader.CodeMaid.Helpers
         /// <param name="point">The point.</param>
         internal static void InsertBlankLineAfterPoint(EditPoint point)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (point.AtEndOfDocument) return;
 
             point.LineDown(1);
@@ -204,6 +220,8 @@ namespace SteveCadwallader.CodeMaid.Helpers
         /// <param name="centerOnWhole">True if the whole element should be used for centering.</param>
         internal static void MoveToCodeItem(Document document, BaseCodeItem codeItem, bool centerOnWhole)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var textDocument = document.GetTextDocument();
             if (textDocument == null) return;
 
@@ -256,6 +274,8 @@ namespace SteveCadwallader.CodeMaid.Helpers
         /// <param name="codeItem">The code item.</param>
         internal static void SelectCodeItem(Document document, BaseCodeItem codeItem)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var textDocument = document.GetTextDocument();
             if (textDocument == null) return;
 
@@ -288,9 +308,12 @@ namespace SteveCadwallader.CodeMaid.Helpers
         internal static void SubstituteAllStringMatches(TextDocument textDocument, string patternString, string replacementString)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var textBuffer = GetTextBufferAt(textDocument.Parent.FullName, CodeMaidPackage.Instance.ComponentModel, CodeMaidPackage.Instance);
-            IFinder finder = GetFinder(patternString, replacementString, textBuffer);
-            ReplaceAll(textBuffer, finder.FindForReplaceAll());
+
+            if (TryGetTextBufferAt(textDocument.Parent.FullName, out ITextBuffer textBuffer))
+            {
+                IFinder finder = GetFinder(patternString, replacementString, textBuffer);
+                ReplaceAll(textBuffer, finder.FindForReplaceAll());
+            }
         }
 
         /// <summary>
@@ -303,9 +326,12 @@ namespace SteveCadwallader.CodeMaid.Helpers
         internal static void SubstituteAllStringMatches(TextSelection textSelection, string patternString, string replacementString)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var textBuffer = GetTextBufferAt(textSelection.Parent.Parent.FullName, CodeMaidPackage.Instance.ComponentModel, CodeMaidPackage.Instance);
-            IFinder finder = GetFinder(patternString, replacementString, textBuffer);
-            ReplaceAll(textBuffer, finder.FindForReplaceAll(GetSnapshotSpanForTextSelection(textBuffer.CurrentSnapshot, textSelection)));
+
+            if (TryGetTextBufferAt(textSelection.Parent.Parent.FullName, out ITextBuffer textBuffer))
+            {
+                IFinder finder = GetFinder(patternString, replacementString, textBuffer);
+                ReplaceAll(textBuffer, finder.FindForReplaceAll(GetSnapshotSpanForTextSelection(textBuffer.CurrentSnapshot, textSelection)));
+            }
         }
 
         /// <summary>
@@ -319,9 +345,12 @@ namespace SteveCadwallader.CodeMaid.Helpers
         internal static void SubstituteAllStringMatches(EditPoint startPoint, EditPoint endPoint, string patternString, string replacementString)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            var textBuffer = GetTextBufferAt(startPoint.Parent.Parent.FullName, CodeMaidPackage.Instance.ComponentModel, CodeMaidPackage.Instance);
-            IFinder finder = GetFinder(patternString, replacementString, textBuffer);
-            ReplaceAll(textBuffer, finder.FindForReplaceAll(GetSnapshotSpanForExtent(textBuffer.CurrentSnapshot, startPoint, endPoint)));
+
+            if (TryGetTextBufferAt(startPoint.Parent.Parent.FullName, out ITextBuffer textBuffer))
+            {
+                IFinder finder = GetFinder(patternString, replacementString, textBuffer);
+                ReplaceAll(textBuffer, finder.FindForReplaceAll(GetSnapshotSpanForExtent(textBuffer.CurrentSnapshot, startPoint, endPoint)));
+            }
         }
 
         #endregion Internal Methods
@@ -400,11 +429,11 @@ namespace SteveCadwallader.CodeMaid.Helpers
             }
         }
 
-        private static ITextBuffer GetTextBufferAt(string filePath, IComponentModel componentModel, IServiceProvider serviceProvider)
+        private static bool TryGetTextBufferAt(string filePath, out ITextBuffer textBuffer)
         {
             IVsWindowFrame windowFrame;
             if (VsShellUtilities.IsDocumentOpen(
-              serviceProvider,
+              CodeMaidPackage.Instance,
               filePath,
               Guid.Empty,
               out var _,
@@ -418,13 +447,15 @@ namespace SteveCadwallader.CodeMaid.Helpers
                     var buffer = lines as IVsTextBuffer;
                     if (buffer != null)
                     {
-                        var editorAdapterFactoryService = componentModel.GetService<IVsEditorAdaptersFactoryService>();
-                        return editorAdapterFactoryService.GetDataBuffer(buffer);
+                        var editorAdapterFactoryService = CodeMaidPackage.Instance.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+                        textBuffer = editorAdapterFactoryService.GetDataBuffer(buffer);
+                        return true;
                     }
                 }
             }
 
-            return null;
+            textBuffer = null;
+            return false;
         }
 
         #endregion

--- a/CodeMaidShared/Logic/Cleaning/UpdateLogic.cs
+++ b/CodeMaidShared/Logic/Cleaning/UpdateLogic.cs
@@ -66,12 +66,11 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
 
             var regionStack = new Stack<string>();
             EditPoint cursor = textDocument.StartPoint.CreateEditPoint();
-            TextRanges subGroupMatches = null; // Not used - required for FindPattern.
             const string pattern = @"^[ \t]*#";
 
             // Keep pushing cursor forwards (note ref cursor parameter) until finished.
             while (cursor != null &&
-                   cursor.FindPattern(pattern, TextDocumentHelper.StandardFindOptions, ref cursor, ref subGroupMatches))
+                   TextDocumentHelper.TryFindNextMatch(startPoint: cursor, endPoint: ref cursor, pattern))
             {
                 // Create a pointer to capture the text for this line.
                 EditPoint eolCursor = cursor.CreateEditPoint();


### PR DESCRIPTION
Replace usage of FindPattern/ReplacePattern with IFindService.

DTE FindPattern and ReplacePattern are not supported in VS 2022, so this change replaces their usage with IFindService.

Addresses several issues listed in #816.
