### PR TITLE
Fixed multiple bugs on file headers update

### DIFF
--- a/CodeMaid.UnitTests/Helpers/FileHeaderHelperTests.cs
+++ b/CodeMaid.UnitTests/Helpers/FileHeaderHelperTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
 using SteveCadwallader.CodeMaid.Helpers;
 using System;
@@ -152,8 +152,8 @@ namespace SteveCadwallader.CodeMaid.UnitTests.Helpers
             Assert.IsTrue(headerLength == expectedLength, $"Expecting {expectedLength}, found {headerLength}");
         }
 
-        [TestCase("//", "using System;\r\n// header\r\n", 11)]
-        [TestCase("//", "using System;\r\n// header I\r\n// header II\r\n", 26)]
+        [TestCase("//", "using System;\r\n// header\r\nnamespace ", 11)]
+        [TestCase("//", "using System;\r\n// header I\r\n// header II\r\nnamespace ", 26)]
         public void GetHeaderLengthMultiSingleLineSkipUsings(string tag, string text, int expectedLength)
         {
             var headerLength = FileHeaderHelper.GetHeaderLength(text, tag, true);
@@ -174,7 +174,7 @@ namespace SteveCadwallader.CodeMaid.UnitTests.Helpers
 
         [TestCase("//", "using System;\r\n\r\n//  header \r\nnamespace System.Windows;\r\npublic class Test\r\n", 13)]
         [TestCase("//", "using EnvDTE;\r\nusing System;\r\nusing SteveCadwallader.CodeMaid.Helpers;\r\n\r\n\r\n//  header \r\n// more header \r\nnamespace SteveCadwallader.CodeMaid;\r\n", 29)]
-        [TestCase("//", "using System;\r\n\r\n//  header \r\n[assembly: AssemblyTitle(\"SteveCadwallader.CodeMaid.UnitTests\")]\r\n", 13)]
+        [TestCase("//", "using System;\r\n\r\n//  header \r\n[assembly: AssemblyTitle(\"SteveCadwallader.CodeMaid.UnitTests\")]\r\nnamespace ", 13)]
         public void GetHeaderLengthMultiSingleLineWithCodeSkipUsings(string tag, string text, int expectedLength)
         {
             var headerLength = FileHeaderHelper.GetHeaderLength(text, tag, true);
@@ -193,7 +193,7 @@ namespace SteveCadwallader.CodeMaid.UnitTests.Helpers
             Assert.IsTrue(headerLength == expectedLength, $"Expecting {expectedLength}, found {headerLength}");
         }
 
-        [TestCase("//", "using System;\r\n\r\n\r\n//  header \r\n// header\r\nnamespace\r\n//not header\r\n public class Test\r\n", 23)]
+        [TestCase("//", "using System;\r\n\r\n\r\n//  header \r\n// header\r\nnamespace \r\n//not header\r\n public class Test\r\n", 23)]
         [TestCase("//", "using EnvDTE;\r\nusing System;\r\nusing SteveCadwallader.CodeMaid.Helpers;\r\n//  header \r\n// more header \r\n namespace System.Text;\r\n{\r\n", 29)]
         public void GetHeaderLengthMultiSingleLineWithEmptyLinesSkipUsings(string tag, string text, int expectedLength)
         {

--- a/CodeMaidShared/Helpers/FileHeaderHelper.cs
+++ b/CodeMaidShared/Helpers/FileHeaderHelper.cs
@@ -1,4 +1,4 @@
-﻿using EnvDTE;
+using EnvDTE;
 using SteveCadwallader.CodeMaid.Properties;
 using SteveCadwallader.CodeMaid.UI.Enumerations;
 using System;
@@ -182,6 +182,12 @@ namespace SteveCadwallader.CodeMaid.Helpers
             header.AddRange(GetLinesStartingWith(commentSyntax, lines, header.Count));
 
             var nbChar = 0;
+
+            if (header.Count() == 0)
+            {
+                return 0;
+            }
+
             header.ToList().ForEach(x => nbChar += x.Length + 1);
 
             return nbChar;
@@ -218,6 +224,12 @@ namespace SteveCadwallader.CodeMaid.Helpers
             }
 
             var nbChar = 0;
+
+            if (header.Count() == 0)
+            {
+                return 0;
+            }
+
             header.ToList().ForEach(x => nbChar += x.Length + 1);
 
             return nbChar;
@@ -234,7 +246,7 @@ namespace SteveCadwallader.CodeMaid.Helpers
             var nbChar = 0;
             header.ToList().ForEach(x => nbChar += x.Length + 1);
 
-            return nbChar + 1;
+            return nbChar == 0 ? 0 : nbChar + 1;
         }
 
         private static int GetHeaderLengthSkipUsings(string text, string commentSyntaxStart, string commentSyntaxEnd)
@@ -251,6 +263,12 @@ namespace SteveCadwallader.CodeMaid.Helpers
 
             var header = text.Substring(startIndex, endIndex - startIndex);
             var nbNewLines = Regex.Matches(header, Environment.NewLine).Count;
+
+            if (header.Length == 0 && nbNewLines == 0)
+            {
+                return 0;
+            }
+
             return header.Length + commentSyntaxEnd.Length - nbNewLines + 1;
         }
 
@@ -313,7 +331,14 @@ namespace SteveCadwallader.CodeMaid.Helpers
                 startIndex = document.IndexOf("using ", startIndex);
             }
 
-            var afterUsingIndex = document.IndexOf($"{Environment.NewLine}", lastUsingIndex) + 1;
+            var afterUsingIndex = 0;
+
+            if (lastUsingIndex != 1)
+            {
+                // if lastUsingIndex == 1 we did not find any using
+                afterUsingIndex = document.IndexOf($"{Environment.NewLine}", lastUsingIndex) + 1;
+            }
+
             return document.Substring(afterUsingIndex).TrimStart();
         }
 

--- a/CodeMaidShared/Helpers/FileHeaderHelper.cs
+++ b/CodeMaidShared/Helpers/FileHeaderHelper.cs
@@ -325,17 +325,21 @@ namespace SteveCadwallader.CodeMaid.Helpers
             var startIndex = 0;
             var lastUsingIndex = 0;
 
-            while (startIndex < namespaceIndex && startIndex++ != -1)
+            while (startIndex < namespaceIndex)
             {
                 lastUsingIndex = startIndex;
                 startIndex = document.IndexOf("using ", startIndex);
+
+                if (startIndex++ == -1)
+                {
+                    break;
+                }
             }
 
             var afterUsingIndex = 0;
 
-            if (lastUsingIndex != 1)
+            if (lastUsingIndex > 0)
             {
-                // if lastUsingIndex == 1 we did not find any using
                 afterUsingIndex = document.IndexOf($"{Environment.NewLine}", lastUsingIndex) + 1;
             }
 

--- a/CodeMaidShared/Logic/Cleaning/FileHeaderLogic.cs
+++ b/CodeMaidShared/Logic/Cleaning/FileHeaderLogic.cs
@@ -192,10 +192,12 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
             switch (FileHeaderHelper.GetFileHeaderPositionFromSettings(textDocument))
             {
                 case HeaderPosition.DocumentStart:
+                    ReplaceFileHeaderAfterUsings(textDocument, string.Empty); // Removes header after usings if present
                     ReplaceFileHeaderDocumentStart(textDocument, settingsFileHeader);
                     return;
 
                 case HeaderPosition.AfterUsings:
+                    ReplaceFileHeaderDocumentStart(textDocument, string.Empty); // Removes header at document start if present
                     ReplaceFileHeaderAfterUsings(textDocument, settingsFileHeader);
                     return;
 

--- a/CodeMaidShared/Logic/Cleaning/FileHeaderLogic.cs
+++ b/CodeMaidShared/Logic/Cleaning/FileHeaderLogic.cs
@@ -144,9 +144,8 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
             Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
 
             var currentHeader = GetCurrentHeader(textDocument, true).Trim();
-            var newHeader = settingsFileHeader.Trim();
 
-            if (string.Equals(currentHeader, newHeader))
+            if (currentHeader.StartsWith(settingsFileHeader.Trim()))
             {
                 return;
             }
@@ -155,6 +154,11 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
             var nbLinesToSkip = GetNbLinesToSkip(textDocument);
 
             headerBlockStart.MoveToLineAndOffset(nbLinesToSkip + 1, 1);
+
+            if (!settingsFileHeader.StartsWith(Environment.NewLine))
+            {
+                settingsFileHeader = Environment.NewLine + settingsFileHeader;
+            }
 
             headerBlockStart.Insert(settingsFileHeader);
         }
@@ -166,7 +170,7 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
             var cursor = textDocument.StartPoint.CreateEditPoint();
             var existingFileHeader = cursor.GetText(settingsFileHeader.Length);
 
-            if (!existingFileHeader.StartsWith(settingsFileHeader.TrimStart()))
+            if (!existingFileHeader.StartsWith(settingsFileHeader.Trim()))
             {
                 cursor.Insert(settingsFileHeader);
             }
@@ -230,6 +234,11 @@ namespace SteveCadwallader.CodeMaid.Logic.Cleaning
             headerBlockStart.MoveToLineAndOffset(nbLinesToSkip + 1, 1);
 
             var currentHeaderLength = GetHeaderLength(textDocument, true);
+
+            if (!settingsFileHeader.StartsWith(Environment.NewLine))
+            {
+                settingsFileHeader = Environment.NewLine + settingsFileHeader;
+            }
 
             headerBlockStart.ReplaceText(currentHeaderLength, settingsFileHeader, (int)vsEPReplaceTextOptions.vsEPReplaceTextKeepMarkers);
         }


### PR DESCRIPTION
- Fixed header replacement management: if a header is already present and a new one is added in another place using the "Replace" option, then the old one is removed.
e.g. if a header is present at document start and we add a new one after usings with the Replace option, the one at document start is now removed
- Header update on files with no header and no using is now working
- Header piece being sometimes inserted after header is now fixed