### PR TITLE
Use an alternate LazyThreadSafetyMode per recommendation.

### DIFF
--- a/CodeMaidShared/Model/CodeItems/BaseCodeItemElement.cs
+++ b/CodeMaidShared/Model/CodeItems/BaseCodeItemElement.cs
@@ -1,6 +1,7 @@
 using EnvDTE;
 using SteveCadwallader.CodeMaid.Helpers;
 using System;
+using System.Threading;
 
 namespace SteveCadwallader.CodeMaid.Model.CodeItems
 {
@@ -122,7 +123,7 @@ namespace SteveCadwallader.CodeMaid.Model.CodeItems
         /// <returns>A lazy initializer for the specified function.</returns>
         protected static Lazy<T> LazyTryDefault<T>(Func<T> func)
         {
-            return new Lazy<T>(() => TryDefault(func));
+            return new Lazy<T>(() => TryDefault(func), LazyThreadSafetyMode.PublicationOnly);
         }
 
         /// <summary>


### PR DESCRIPTION
Proposed in #948 

I'm not positive this will address the issue as the provided call stacks only show one thread coming into this function.  It seems this would help if there were two separate threads both calling into the same initializer.  I'm putting it up for PR though if anyone has ideas on how to reproduce the original issue or more context.