### PR TITLE
Fix compatibility problem with arm64 architecture

### DIFF
--- a/CodeMaid.UnitTests/CodeMaid.UnitTests.csproj
+++ b/CodeMaid.UnitTests/CodeMaid.UnitTests.csproj
@@ -81,25 +81,25 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>16.10.31321.278</Version>
+      <Version>17.6.36389</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.0.0</Version>
+      <Version>17.6.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.2.7</Version>
+      <Version>3.0.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.2.7</Version>
+      <Version>3.0.4</Version>
     </PackageReference>
     <PackageReference Include="NSubstitute">
-      <Version>4.2.2</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
-      <Version>3.13.2</Version>
+      <Version>3.13.3</Version>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter">
-      <Version>4.0.0</Version>
+      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
   <Choose>

--- a/CodeMaid.VS2022/CodeMaid.VS2022.csproj
+++ b/CodeMaid.VS2022/CodeMaid.VS2022.csproj
@@ -722,12 +722,13 @@
       <Version>1.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.0.0-previews-2-31512-422</Version>
+      <Version>17.6.36389</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.3177-preview3</Version>
+      <Version>17.6.2164</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/CodeMaid.VS2022/source.extension.vsixmanifest
+++ b/CodeMaid.VS2022/source.extension.vsixmanifest
@@ -14,6 +14,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />

--- a/CodeMaid/CodeMaid.csproj
+++ b/CodeMaid/CodeMaid.csproj
@@ -340,12 +340,13 @@
       <Version>1.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>16.10.31321.278</Version>
+      <Version>17.6.36389</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>16.11.35</Version>
+      <Version>17.6.2164</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Hello,

I propose a few changes to make the extension compatible with VS 2022 installation on ARM64 architecture.
I have made the update of the NuGet packages and added the target "arm64" to the .vsixmanifest file.

The compilation is successful and I installed the extension to my VS 2022 running on Windows 11 virtualized with parallels desktop on a Macbook Pro (M2 Max chip) computer.